### PR TITLE
Changes made to Orders V2 spec.

### DIFF
--- a/openapi/checkout_orders_v2.json
+++ b/openapi/checkout_orders_v2.json
@@ -42,14 +42,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-create-response400-json"
                 }
               }
             }
@@ -59,14 +52,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_401"
-                    },
-                    {
-                      "$ref": "#/components/schemas/401"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-create-response401-json"
                 }
               }
             }
@@ -76,14 +62,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-create-response422-json"
                 }
               }
             }
@@ -104,9 +83,6 @@
           },
           {
             "$ref": "#/components/parameters/prefer"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           }
         ],
         "requestBody": {
@@ -158,14 +134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_401"
-                    },
-                    {
-                      "$ref": "#/components/schemas/401"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-get-response401-json"
                 }
               }
             }
@@ -175,14 +144,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_404"
-                    },
-                    {
-                      "$ref": "#/components/schemas/404"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-get-response404-json"
                 }
               }
             }
@@ -194,9 +156,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/id"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           },
           {
             "$ref": "#/components/parameters/fields"
@@ -227,14 +186,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.patch-400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-patch-response400-json"
                 }
               }
             }
@@ -244,14 +196,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_401"
-                    },
-                    {
-                      "$ref": "#/components/schemas/401"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-patch-response401-json"
                 }
               }
             }
@@ -261,14 +206,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_404"
-                    },
-                    {
-                      "$ref": "#/components/schemas/404"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-patch-response404-json"
                 }
               }
             }
@@ -278,14 +216,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.patch-422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-patch-response422-json"
                 }
               }
             }
@@ -297,9 +228,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/id"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           }
         ],
         "requestBody": {
@@ -339,14 +267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.confirm-400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-confirm-response400-json"
                 }
               }
             }
@@ -356,14 +277,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_403"
-                    },
-                    {
-                      "$ref": "#/components/schemas/403"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-confirm-response403-json"
                 }
               }
             }
@@ -373,14 +287,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.confirm-422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-confirm-response422-json"
                 }
               }
             }
@@ -401,13 +308,10 @@
         },
         "parameters": [
           {
-            "$ref": "#/components/parameters/paypal_client_metadata_id"
-          },
-          {
             "$ref": "#/components/parameters/id"
           },
           {
-            "$ref": "#/components/parameters/content_type"
+            "$ref": "#/components/parameters/paypal_client_metadata_id"
           },
           {
             "$ref": "#/components/parameters/prefer"
@@ -471,14 +375,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.authorize-400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-authorize-response400-json"
                 }
               }
             }
@@ -488,14 +385,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_401"
-                    },
-                    {
-                      "$ref": "#/components/schemas/401"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-authorize-response401-json"
                 }
               }
             }
@@ -505,14 +395,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_403"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.authorize-403"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-authorize-response403-json"
                 }
               }
             }
@@ -522,14 +405,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_404"
-                    },
-                    {
-                      "$ref": "#/components/schemas/404"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-authorize-response404-json"
                 }
               }
             }
@@ -539,14 +415,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.authorize-422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-authorize-response422-json"
                 }
               }
             }
@@ -567,6 +436,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/id"
+          },
+          {
             "$ref": "#/components/parameters/paypal_request_id"
           },
           {
@@ -576,13 +448,7 @@
             "$ref": "#/components/parameters/paypal_client_metadata_id"
           },
           {
-            "$ref": "#/components/parameters/id"
-          },
-          {
             "$ref": "#/components/parameters/paypal_auth_assertion"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           }
         ],
         "requestBody": {
@@ -638,14 +504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.capture-400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-capture-response400-json"
                 }
               }
             }
@@ -655,14 +514,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_401"
-                    },
-                    {
-                      "$ref": "#/components/schemas/401"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-capture-response401-json"
                 }
               }
             }
@@ -672,14 +524,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_403"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.capture-403"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-capture-response403-json"
                 }
               }
             }
@@ -689,14 +534,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_404"
-                    },
-                    {
-                      "$ref": "#/components/schemas/404"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-capture-response404-json"
                 }
               }
             }
@@ -706,14 +544,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.capture-422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-capture-response422-json"
                 }
               }
             }
@@ -734,6 +565,9 @@
         },
         "parameters": [
           {
+            "$ref": "#/components/parameters/id"
+          },
+          {
             "$ref": "#/components/parameters/paypal_request_id"
           },
           {
@@ -743,13 +577,7 @@
             "$ref": "#/components/parameters/paypal_client_metadata_id"
           },
           {
-            "$ref": "#/components/parameters/id"
-          },
-          {
             "$ref": "#/components/parameters/paypal_auth_assertion"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           }
         ],
         "requestBody": {
@@ -805,14 +633,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.track.create-400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-track-create-response400-json"
                 }
               }
             }
@@ -822,14 +643,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_403"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.track.create-403"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-track-create-response403-json"
                 }
               }
             }
@@ -839,14 +653,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_404"
-                    },
-                    {
-                      "$ref": "#/components/schemas/404"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-track-create-response404-json"
                 }
               }
             }
@@ -856,14 +663,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.track.create-422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-track-create-response422-json"
                 }
               }
             }
@@ -888,9 +688,6 @@
           },
           {
             "$ref": "#/components/parameters/paypal_auth_assertion"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           }
         ],
         "requestBody": {
@@ -929,14 +726,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_400"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.trackers.patch-400"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-trackers-patch-response400-json"
                 }
               }
             }
@@ -946,14 +736,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_403"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.trackers.patch-403"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-trackers-patch-response403-json"
                 }
               }
             }
@@ -963,14 +746,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_404"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.trackers.patch-404"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-trackers-patch-response404-json"
                 }
               }
             }
@@ -980,14 +756,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "allOf": [
-                    {
-                      "$ref": "#/components/schemas/error_422"
-                    },
-                    {
-                      "$ref": "#/components/schemas/orders.trackers.patch-422"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/orders-trackers-patch-response422-json"
                 }
               }
             }
@@ -1012,9 +781,6 @@
           },
           {
             "$ref": "#/components/parameters/tracker_id"
-          },
-          {
-            "$ref": "#/components/parameters/content_type"
           }
         ],
         "requestBody": {
@@ -1135,18 +901,6 @@
           "default": "return=minimal"
         }
       },
-      "content_type": {
-        "name": "Content-Type",
-        "in": "header",
-        "description": "The media type. Required for operations with a request body. The value is `application/<format>`, where `format` is `json`.",
-        "required": true,
-        "schema": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 255,
-          "default": "application/json"
-        }
-      },
       "id": {
         "name": "id",
         "in": "path",
@@ -1204,1996 +958,38 @@
       }
     },
     "schemas": {
-      "400": {
+      "bad_request_error": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_ARRAY_MAX_ITEMS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_ARRAY_MAX_ITEMS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The number of items in an array parameter is too large."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_ARRAY_MIN_ITEMS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_ARRAY_MIN_ITEMS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The number of items in an array parameter is too small."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_COUNTRY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_COUNTRY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Country code is invalid. Please refer to https://developer.paypal.com/api/rest/reference/country-codes/ for a list of supported country codes."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_SYNTAX",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_SYNTAX"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field does not conform to the expected format."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A parameter value is not valid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required parameter is missing."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This field is not currently supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_REQUEST_ID_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_REQUEST_ID_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A PayPal-Request-Id is required if you are trying to process payment for an Order. Please specify a PayPal-Request-Id or Create the Order without a 'payment_source' specified."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MALFORMED_REQUEST_JSON",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MALFORMED_REQUEST_JSON"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request JSON is not well formed."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/bad-request-error-issues"
           }
         }
       },
-      "401": {
+      "unauthorized_request_error": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_ACCOUNT_STATUS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_ACCOUNT_STATUS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Account validations failed for the user."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/unauthorized-request-error-issues"
           }
         }
       },
-      "403": {
+      "forbidden_error": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "PERMISSION_DENIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You do not have permission to access or perform operations on this resource."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_FOR_CARD_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_FOR_CARD_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The recipient for which the API call is made on behalf of is not enabled for card processing. Please contact PayPal customer support."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_ACCOUNT_NOT_VERIFIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_ACCOUNT_NOT_VERIFIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payee has not verified their account with PayPal. The selected payment method requires the recipient to have a verified PayPal account before transactions can be processed on their behalf."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/forbidden-error-issues"
           }
         }
       },
-      "404": {
+      "not_found_error": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_RESOURCE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_RESOURCE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified resource ID does not exist. Please check the resource ID and try again."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/not-found-error-issues"
           }
         }
       },
-      "422": {
+      "unprocessable_entity_error": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANNOT_BE_NEGATIVE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANNOT_BE_NEGATIVE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Must be greater than or equal to 0. If the currency supports decimals, only two decimal place precision is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANNOT_BE_ZERO_OR_NEGATIVE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANNOT_BE_ZERO_OR_NEGATIVE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Must be greater than zero. If the currency supports decimals, only two decimal place precision is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card is expired"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_PREVIOUS_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_PREVIOUS_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_CRYPTOGRAM",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_CRYPTOGRAM"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is mandatory for any customer initiated network token transactions."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CITY_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CITY_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified country requires a city (address.admin_area_2)."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DECIMAL_PRECISION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DECIMAL_PRECISION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If the currency supports decimals, only two decimal place precision is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DONATION_ITEMS_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DONATION_ITEMS_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If 'purchase_unit' has \"DONATION\" as the 'items.category' then the Order can at most have one purchase_unit. Multiple purchase_units are not supported if either of them have at least one items with category as \"DONATION\"."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DUPLICATE_REFERENCE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DUPLICATE_REFERENCE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`reference_id` must be unique if multiple `purchase_unit` are provided."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_CURRENCY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_CURRENCY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Currency code is invalid or is not currently supported. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PAYER_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PAYER_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payer ID is not valid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_TOTAL_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_TOTAL_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should equal sum of (unit_amount * quantity) across all items for a given purchase_unit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_TOTAL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_TOTAL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If item details are specified (items.unit_amount and items.quantity) corresponding amount.breakdown.item_total is required."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MAX_VALUE_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MAX_VALUE_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should be less than or equal to 999999999999999.99."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_PICKUP_ADDRESS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_PICKUP_ADDRESS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A pickup address(`shipping.address`) is required for the provided `shipping.type`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTI_CURRENCY_ORDER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTI_CURRENCY_ORDER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Multiple differing values of currency_code are not supported. Entire Order request must have the same currency_code."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTIPLE_ITEM_CATEGORIES",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTIPLE_ITEM_CATEGORIES"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "For a given 'purchase_unit' the 'items.category' could be either \"PHYSICAL_GOODS\" and/or \"DIGITAL_GOODS\" or just \"DONATION\".  'items.category' as \"DONATION\" cannot be combined with items with either \"PHYSICAL_GOODS\" or \"DIGITAL_GOODS\"."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTIPLE_SHIPPING_ADDRESS_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTIPLE_SHIPPING_ADDRESS_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Multiple shipping addresses are not supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTIPLE_SHIPPING_TYPE_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTIPLE_SHIPPING_TYPE_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Different `shipping.type` are not supported across purchase units."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_ACCOUNT_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_ACCOUNT_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payee account specified is invalid. Please check the `payee.email_address` or `payee.merchant_id` specified and try again. Ensure that either  `payee.merchant_id` or `payee.email_address` is specified."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_ACCOUNT_LOCKED_OR_CLOSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_ACCOUNT_LOCKED_OR_CLOSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The merchant account is locked or closed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_ACCOUNT_RESTRICTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_ACCOUNT_RESTRICTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The merchant account is restricted."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_PRICING_TIER_ID_NOT_ENABLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_PRICING_TIER_ID_NOT_ENABLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller is not enabled to process transactions by specifying a 'payee_pricing_tier_id'. Please work with your Account Manager to enable this option for your account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PAYEE_PRICING_TIER_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PAYEE_PRICING_TIER_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Please check the value specified or confirm with your Account Manager that the 'payee_pricing_tier_id' specified has been setup for the account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_FX_RATE_ID_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_FX_RATE_ID_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified FX Rate ID is for a currency that does not match with the currency of this request. Please specify a different FX Rate ID and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_FX_RATE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_FX_RATE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specific FX Rate ID is not valid. This could be either because we are not able to look up the FX Rate based on this ID or it could be because the ID belongs to another API Caller."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PLATFORM_FEES_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PLATFORM_FEES_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller is not enabled to process transactions by specifying 'platform_fees'. Please work with your PayPal Account Manager to enable this option for your account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PLATFORM_FEES_ACCOUNT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PLATFORM_FEES_ACCOUNT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified platform_fees payee account is either invalid or account setup is incomplete.Please work with your PayPal Account Manager to enable this option for your account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PLATFORM_FEES_AMOUNT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PLATFORM_FEES_AMOUNT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The platform_fees amount cannot be greater than order amount."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "POSTAL_CODE_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "POSTAL_CODE_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified country requires a postal code."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REFERENCE_ID_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REFERENCE_ID_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "'reference_id' is required for each 'purchase_unit' if multiple 'purchase_unit' are provided."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_OPTIONS_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_OPTIONS_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Shipping options are not supported when `shipping.type` is specified or when 'application_context.shipping_preference' is set as 'NO_SHIPPING' or 'SET_PROVIDED_ADDRESS'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TAX_TOTAL_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TAX_TOTAL_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should equal sum of (tax * quantity) across all items for a given purchase_unit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TAX_TOTAL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TAX_TOTAL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If item details are specified (items.tax_total and items.quantity) corresponding amount.breakdown.tax_total is required."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_INTENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_INTENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`intent=AUTHORIZE` is not supported for multiple purchase units. Only `intent=CAPTURE` is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_PAYMENT_INSTRUCTION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_PAYMENT_INSTRUCTION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You must provide the payment instruction when you capture an authorized payment for `intent=AUTHORIZE`. For details, see <a href=\"/docs/api/payments/v2/#authorizations_capture\">Capture authorization</a>. For `intent=CAPTURE`, send the payment instruction when you create the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_TYPE_NOT_SUPPORTED_FOR_CLIENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_TYPE_NOT_SUPPORTED_FOR_CLIENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller account is not setup to be able to support a `shipping.type`=`PICKUP_IN_PERSON`. This feature is only supported for <a href=\"https://www.paypal.com/us/business/platforms-and-marketplaces\">PayPal Commerce Platform for Platforms and Marketplaces</a>."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_SHIPPING_TYPE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_SHIPPING_TYPE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided `shipping.type` is only supported for `application_context.shipping_preference`=`SET_PROVIDED_ADDRESS` or `NO_SHIPPING`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_OPTION_NOT_SELECTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_OPTION_NOT_SELECTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "At least one of the shipping.option should be set to 'selected = true'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_OPTIONS_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_OPTIONS_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Shipping options are not supported when 'application_context.shipping_preference' is set as 'NO_SHIPPING' or 'SET_PROVIDED_ADDRESS'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTIPLE_SHIPPING_OPTION_SELECTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTIPLE_SHIPPING_OPTION_SELECTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Only one shipping.option can be set to 'selected = true'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The amount provided in the preferred shipping option should match the amount provided in amount breakdown"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AGREEMENT_ALREADY_CANCELLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AGREEMENT_ALREADY_CANCELLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The requested agreement is already canceled."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_AGREEMENT_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_AGREEMENT_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The requested Billing Agreement token was not found."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "COMPLIANCE_VIOLATION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "COMPLIANCE_VIOLATION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction is declined due to compliance violation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DOMESTIC_TRANSACTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DOMESTIC_TRANSACTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This transaction requires the payee and payer to be resident in the same country, a domestic transaction is required to create this payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DUPLICATE_INVOICE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DUPLICATE_INVOICE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Duplicate Invoice ID detected. To avoid a potential duplicate transaction your account setting requires that Invoice Id be unique for each transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INSTRUMENT_DECLINED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INSTRUMENT_DECLINED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The instrument presented  was either declined by the processor or bank, or it can't be used for this payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You have exceeded the maximum number of payment attempts."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_FOR_CARD_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_FOR_CARD_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller account is not setup to be able to process card payments. Please contact PayPal customer support."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_BLOCKED_TRANSACTION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_BLOCKED_TRANSACTION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The Fraud settings for this seller are such that this payment cannot be executed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACCOUNT_LOCKED_OR_CLOSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_LOCKED_OR_CLOSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payer account cannot be used for this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACCOUNT_RESTRICTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_RESTRICTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_RESTRICTED"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_CANNOT_PAY",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_CANNOT_PAY"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Combination of payer and payee settings mean that this buyer cannot pay this seller."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_BLOCKED_BY_PAYEE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_BLOCKED_BY_PAYEE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction blocked by Payee’s Fraud Protection settings."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_LIMIT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_LIMIT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Total payment amount exceeded transaction limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_RECEIVING_LIMIT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The transaction exceeds the receiver's receiving limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_REFUSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_REFUSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request was refused."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AUTH_CAPTURE_NOT_ENABLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AUTH_CAPTURE_NOT_ENABLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Authorization and Capture feature is not enabled for the merchant. Make sure that the recipient of the funds is a verified business account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_PROCESSING_INSTRUCTION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_PROCESSING_INSTRUCTION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified processing_instruction is not supported for the given payment_source. Please refer to https://developer.paypal.com/api/orders/v2/#definition-processing_instruction for the list of payment_source that can be specified with this value."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_COMPLETE_ON_PAYMENT_APPROVAL",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_COMPLETE_ON_PAYMENT_APPROVAL"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A processing_instruction of `ORDER_COMPLETE_ON_PAYMENT_APPROVAL` is required for the specified payment_source. Please refer to the integration guide https://developer.paypal.com/docs/limited-release/alternative-payment-methods-with-orders/ for more details"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_EXPIRY_DATE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_EXPIRY_DATE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Expiry date is invalid. Expiry date should be a date in future and within the threshold for the payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INCOMPATIBLE_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INCOMPATIBLE_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of the field is incompatible/redundant with other fields in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PREVIOUS_TRANSACTION_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PREVIOUS_TRANSACTION_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The authorization or capture referenced by `previous_transaction_reference` is not valid. This could be either because the previous_transaction_reference is not found or doesn't belong to the payee. Please use a valid `previous_transaction_reference`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The capture referenced by `previous_transaction_reference` has a chargeback and hence cannot be used for this order. Please use a `previous_transaction_reference` which does not have a chargeback."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREVIOUS_TRANSACTION_REFERENCE_VOIDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREVIOUS_TRANSACTION_REFERENCE_VOIDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The status of authorization referenced by `previous_transaction_reference` is `VOIDED` and hence cannot be used for this order. Please use a `previous_transaction_reference` whose status is not `VOIDED`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The `payment_source` in the request must match the `payment_source` used for the authorization or capture referenced by `previous_transaction_reference`. Please use `previous_transaction_reference` whose `payment_source` matches with the `payment_source` specified in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_SECURITY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_SECURITY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if `payment_source.card.security_code` is present in the order. `security_code` can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with `security_code` is the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if 3D-Secure authentication results are present in the order. 3D-Secure authentication results can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with 3D-Secure authentication results is the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if more than one purchase_unit is present in the Order. Merchant initiated payments are not supported from orders with more than one purchase_unit. Please retry the request with multiple Order requests (one for each purchase_unit)."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The combination of the payment_source name, billing address, shipping name and shipping address could not be verified. Please correct this information and try again by creating a new order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided payment source is declined by the processor. Please try again with a different payment source by creating a new order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_CANNOT_BE_USED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_CANNOT_BE_USED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided payment source cannot be used to pay for the order. Please try again with a different payment source by creating a new order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_FOR_APPLE_PAY",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_FOR_APPLE_PAY"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The 'API caller' and/or 'payee' is not setup to be able to process apple pay. Please contact your Account Manager."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_FOR_GOOGLE_PAY",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_FOR_GOOGLE_PAY"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The 'API caller' and/or 'payee' is not setup to be able to process google pay. Please contact your Account Manager."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "APPLE_PAY_AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "APPLE_PAY_AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_ADDRESS_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_ADDRESS_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided billing address is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_ADDRESS_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_ADDRESS_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided shipping address is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "VAULT_INSTRUCTION_DUPLICATED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "VAULT_INSTRUCTION_DUPLICATED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Only one vault instruction is allowed. Please use `vault.store_in_vault` to provide vault instruction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "VAULT_INSTRUCTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "VAULT_INSTRUCTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CRYPTOGRAM_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CRYPTOGRAM_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "EMV_DATA_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "EMV_DATA_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "EMV Data is required if authentication method is EMV."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_TRANSACTION_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PNREF_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PNREF_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `pnref` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_SECURITY_CODE_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_SECURITY_CODE_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The security_code length is invalid for the specified card brand."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API caller or the merchant on whose behalf the API call is initiated is not allowed to vault the given source. Please contact PayPal customer support for assistance."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TOKEN_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TOKEN_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The token is expired and cannot be used for payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_GOOGLE_PAY_TOKEN",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_GOOGLE_PAY_TOKEN"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The google pay token is invalid. PayPal was not able to decrypt the googlepay token or PayPal was not able to find the necessary data in the token after decryption."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The gateway merchant ID in Google Pay token is not valid. This could be because the gateway merchant Id that was authorized by payer/buyer on Google Pay does not match with the API caller of the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CRYPTOGRAM_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CRYPTOGRAM_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ONE_OF_PARAMETERS_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ONE_OF_PARAMETERS_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "One or more field is required to continue with this request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ALIAS_DECLINED_BY_PROCESSOR",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ALIAS_DECLINED_BY_PROCESSOR"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided alias was declined by the processor. Please create a new order with a different alias_key and/or alias_label and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Blik's one_click flow requires one_click.auth_code and one_click.alias_label parameters for the buyer's first transaction. For all subsequent transactions,only the one_click.alias_key parameter is required."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/unprocessable-entity-error-issues"
           }
         }
       },
@@ -3266,22 +1062,13 @@
         "description": "Error response for 400",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "INVALID_REQUEST"
-            ]
+            "$ref": "#/components/schemas/error400-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "Request is not well-formed, syntactically incorrect, or violates schema."
-            ]
+            "$ref": "#/components/schemas/error400-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error400-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3300,22 +1087,13 @@
         "description": "Error response for 401",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "AUTHENTICATION_FAILURE"
-            ]
+            "$ref": "#/components/schemas/error401-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "Authentication failed due to missing authorization header, or invalid authentication credentials."
-            ]
+            "$ref": "#/components/schemas/error401-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error401-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3334,22 +1112,13 @@
         "description": "Error response for 403",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "NOT_AUTHORIZED"
-            ]
+            "$ref": "#/components/schemas/error403-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "Authorization failed due to insufficient permissions."
-            ]
+            "$ref": "#/components/schemas/error403-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error403-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3368,22 +1137,13 @@
         "description": "Error response for 404",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "RESOURCE_NOT_FOUND"
-            ]
+            "$ref": "#/components/schemas/error404-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "The specified resource does not exist."
-            ]
+            "$ref": "#/components/schemas/error404-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error404-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3402,22 +1162,13 @@
         "description": "Error response for 409",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "RESOURCE_CONFLICT"
-            ]
+            "$ref": "#/components/schemas/error409-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "The server has detected a conflict while processing this request."
-            ]
+            "$ref": "#/components/schemas/error409-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error409-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3432,26 +1183,17 @@
       },
       "error_415": {
         "type": "object",
-        "title": "409 Error",
+        "title": "415 Error",
         "description": "Error response for 415",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "UNSUPPORTED_MEDIA_TYPE"
-            ]
+            "$ref": "#/components/schemas/error415-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "The server does not support the request payload's media type."
-            ]
+            "$ref": "#/components/schemas/error415-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error415-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3470,22 +1212,13 @@
         "description": "Error response for 422",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "UNPROCESSABLE_ENTITY"
-            ]
+            "$ref": "#/components/schemas/error422-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "The requested action could not be performed, semantically incorrect, or failed business validation."
-            ]
+            "$ref": "#/components/schemas/error422-message"
           },
           "issues": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/error_details"
-            }
+            "$ref": "#/components/schemas/error422-issues"
           },
           "debug_id": {
             "type": "string",
@@ -3504,28 +1237,17 @@
         "description": "Error response for 500",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "INTERNAL_SERVER_ERROR"
-            ]
+            "$ref": "#/components/schemas/error500-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "An internal server error occurred."
-            ]
+            "$ref": "#/components/schemas/error500-message"
           },
           "debug_id": {
             "type": "string",
             "description": "The PayPal internal ID. Used for correlation purposes."
           },
           "information_link": {
-            "type": "string",
-            "description": "The information link, or URI, that shows detailed information about this error for the developer.",
-            "enum": [
-              "https://developer.paypal.com/api/orders/v2/#error-INTERNAL_SERVER_ERROR"
-            ],
-            "readOnly": true
+            "$ref": "#/components/schemas/error500-information-link"
           }
         },
         "example": {
@@ -3541,16 +1263,10 @@
         "description": "Error response for 503",
         "properties": {
           "name": {
-            "type": "string",
-            "enum": [
-              "SERVICE_UNAVAILABLE"
-            ]
+            "$ref": "#/components/schemas/error503-name"
           },
           "message": {
-            "type": "string",
-            "enum": [
-              "Service Unavailable."
-            ]
+            "$ref": "#/components/schemas/error503-message"
           },
           "debug_id": {
             "type": "string",
@@ -3567,6 +1283,28 @@
           "message": "Service Unavailable.",
           "debug_id": "90957fca61718",
           "information_link": "https://developer.paypal.com/docs/api/orders/v2/#error-SERVICE_UNAVAILABLE"
+        }
+      },
+      "not_enabled_for_card_processing": {
+        "title": "NOT_ENABLED_FOR_CARD_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-enabled-for-card-processing-issue"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "shipping_option_not_supported": {
+        "title": "SHIPPING_OPTIONS_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-option-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-option-not-supported-description"
+          }
         }
       },
       "checkout_payment_intent": {
@@ -3601,19 +1339,16 @@
         "description": "The customer who approves and pays for the order. The customer is also known as the payer.",
         "properties": {
           "email_address": {
-            "description": "The email address of the payer.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/payer-base-email-address"
           },
           "payer_id": {
-            "description": "The PayPal-assigned ID for the payer.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/account_id"
+            "$ref": "#/components/schemas/payer-base-payer-id"
           }
         }
       },
       "name": {
         "type": "object",
-        "title": "Name",
+        "title": "Party Name",
         "description": "The name of the party.",
         "properties": {
           "prefix": {
@@ -3706,8 +1441,7 @@
             "$ref": "#/components/schemas/phone_type"
           },
           "phone_number": {
-            "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Supports only the `national_number` property.",
-            "$ref": "#/components/schemas/phone"
+            "$ref": "#/components/schemas/phone-with-type-phone-number"
           }
         },
         "required": [
@@ -3735,15 +1469,7 @@
             "pattern": "([a-zA-Z0-9])"
           },
           "tax_id_type": {
-            "type": "string",
-            "description": "The customer's tax ID type.",
-            "minLength": 1,
-            "maxLength": 14,
-            "pattern": "^[A-Z0-9_]+$",
-            "enum": [
-              "BR_CPF",
-              "BR_CNPJ"
-            ]
+            "$ref": "#/components/schemas/tax-info-tax-id-type"
           }
         },
         "required": [
@@ -3761,7 +1487,7 @@
       },
       "address_portable": {
         "type": "object",
-        "title": "Portable Postal Address (Medium-Grained)",
+        "title": "Portable International Postal Address",
         "description": "The portable international postal address. Maps to [AddressValidationMetadata](https://github.com/googlei18n/libaddressinput/wiki/AddressValidationMetadata) and HTML 5.1 [Autofilling form controls: the autocomplete attribute](https://www.w3.org/TR/html51/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).",
         "properties": {
           "address_line_1": {
@@ -3808,41 +1534,7 @@
             "$ref": "#/components/schemas/country_code"
           },
           "address_details": {
-            "type": "object",
-            "title": "Address Details",
-            "description": "The non-portable additional address details that are sometimes needed for compliance, risk, or other scenarios where fine-grain address information might be needed. Not portable with common third party and open source. Redundant with core fields.<br/>For example, `address_portable.address_line_1` is usually a combination of `address_details.street_number`, `street_name`, and `street_type`.",
-            "properties": {
-              "street_number": {
-                "type": "string",
-                "description": "The street number.",
-                "maxLength": 100
-              },
-              "street_name": {
-                "type": "string",
-                "description": "The street name. Just `Drury` in `Drury Lane`.",
-                "maxLength": 100
-              },
-              "street_type": {
-                "type": "string",
-                "description": "The street type. For example, avenue, boulevard, road, or expressway.",
-                "maxLength": 100
-              },
-              "delivery_service": {
-                "type": "string",
-                "description": "The delivery service. Post office box, bag number, or post office name.",
-                "maxLength": 100
-              },
-              "building_name": {
-                "type": "string",
-                "description": "A named locations that represents the premise. Usually a building name or number or collection of buildings with a common name or number. For example, <code>Craven House</code>.",
-                "maxLength": 100
-              },
-              "sub_building": {
-                "type": "string",
-                "description": "The first-order entity below a named building or location that represents the sub-premises. Usually a single building within a collection of buildings with a common name. Can be a flat, story, floor, room, or apartment.",
-                "maxLength": 100
-              }
-            }
+            "$ref": "#/components/schemas/address-details"
           }
         },
         "required": [
@@ -3859,28 +1551,7 @@
             "$ref": "#/components/schemas/payer_base"
           },
           {
-            "properties": {
-              "name": {
-                "description": "The name of the payer. Supports only the `given_name` and `surname` properties.",
-                "$ref": "#/components/schemas/name"
-              },
-              "phone": {
-                "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
-                "$ref": "#/components/schemas/phone_with_type"
-              },
-              "birth_date": {
-                "description": "The birth date of the payer in `YYYY-MM-DD` format.",
-                "$ref": "#/components/schemas/date_no_time"
-              },
-              "tax_info": {
-                "description": "The tax information of the payer. Required only for Brazilian payer's. Both `tax_id` and `tax_id_type` are required.",
-                "$ref": "#/components/schemas/tax_info"
-              },
-              "address": {
-                "description": "The address of the payer. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
-                "$ref": "#/components/schemas/address_portable"
-              }
-            }
+            "$ref": "#/components/schemas/payer-allof1"
           }
         ]
       },
@@ -3917,32 +1588,25 @@
         "title": "Amount Breakdown",
         "properties": {
           "item_total": {
-            "description": "The subtotal for all items. Required if the request includes `purchase_units[].items[].unit_amount`. Must equal the sum of `(items[].unit_amount * items[].quantity)` for all items. <code>item_total.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-item-total"
           },
           "shipping": {
-            "description": "The shipping fee for all items within a given `purchase_unit`. <code>shipping.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-shipping"
           },
           "handling": {
-            "description": "The handling fee for all items within a given `purchase_unit`. <code>handling.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-handling"
           },
           "tax_total": {
-            "description": "The total tax for all items. Required if the request includes `purchase_units.items.tax`. Must equal the sum of `(items[].tax * items[].quantity)` for all items. <code>tax_total.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-tax-total"
           },
           "insurance": {
-            "description": "The insurance fee for all items within a given `purchase_unit`. <code>insurance.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-insurance"
           },
           "shipping_discount": {
-            "description": "The shipping discount for all items within a given `purchase_unit`. <code>shipping_discount.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-shipping-discount"
           },
           "discount": {
-            "description": "The discount for all items within a given `purchase_unit`. <code>discount.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/amount-breakdown-discount"
           }
         }
       },
@@ -3955,11 +1619,7 @@
             "$ref": "#/components/schemas/money"
           },
           {
-            "properties": {
-              "breakdown": {
-                "$ref": "#/components/schemas/amount_breakdown"
-              }
-            }
+            "$ref": "#/components/schemas/amount-with-breakdown-allof1"
           }
         ]
       },
@@ -3969,12 +1629,10 @@
         "description": "The details for the merchant who receives the funds and fulfills the order. The merchant is also known as the payee.",
         "properties": {
           "email_address": {
-            "description": "The email address of merchant.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/payee-base-email-address"
           },
           "merchant_id": {
-            "description": "The encrypted PayPal account ID of the merchant.",
-            "$ref": "#/components/schemas/account_id"
+            "$ref": "#/components/schemas/payee-base-merchant-id"
           }
         }
       },
@@ -3987,7 +1645,7 @@
             "$ref": "#/components/schemas/payee_base"
           },
           {
-            "properties": {}
+            "additionalProperties": true
           }
         ]
       },
@@ -3997,12 +1655,10 @@
         "description": "The platform or partner fee, commission, or brokerage fee that is associated with the transaction. Not a separate or isolated transaction leg from the external perspective. The platform fee is limited in scope and is always associated with the original payment for the purchase unit.",
         "properties": {
           "amount": {
-            "description": "The fee for this transaction.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/platform-fee-amount"
           },
           "payee": {
-            "description": "The recipient of the fee for this transaction. If you omit this value, the default is the API caller.",
-            "$ref": "#/components/schemas/payee_base"
+            "$ref": "#/components/schemas/platform-fee-payee"
           }
         },
         "required": [
@@ -4028,17 +1684,10 @@
         "description": "Any additional payment instructions to be consider during payment processing. This processing instruction is applicable for Capturing an order or Authorizing an Order.",
         "properties": {
           "platform_fees": {
-            "type": "array",
-            "description": "An array of various fees, commissions, tips, or donations. This field is only applicable to merchants that been enabled for PayPal Commerce Platform for Marketplaces and Platforms capability.",
-            "minItems": 0,
-            "maxItems": 1,
-            "items": {
-              "$ref": "#/components/schemas/platform_fee"
-            }
+            "$ref": "#/components/schemas/payment-instruction-platform-fees"
           },
           "disbursement_mode": {
-            "description": "The funds that are held payee by the marketplace/platform. This field is only applicable to merchants that been enabled for PayPal Commerce Platform for Marketplaces and Platforms capability.",
-            "$ref": "#/components/schemas/disbursement_mode"
+            "$ref": "#/components/schemas/payment-instruction-disbursement-mode"
           },
           "payee_pricing_tier_id": {
             "type": "string",
@@ -4068,12 +1717,10 @@
             "maxLength": 127
           },
           "unit_amount": {
-            "description": "The item price or rate per unit. If you specify <code>unit_amount</code>, <code>purchase_units[].amount.breakdown.item_total</code> is required. Must equal <code>unit_amount * quantity</code> for all items. <code>unit_amount.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/item-unit-amount"
           },
           "tax": {
-            "description": "The item tax for each unit. If <code>tax</code> is specified, <code>purchase_units[].amount.breakdown.tax_total</code> is required. Must equal <code>tax * quantity</code> for all items. <code>tax.value</code> can not be a negative number.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/item-tax"
           },
           "quantity": {
             "type": "string",
@@ -4092,15 +1739,7 @@
             "maxLength": 127
           },
           "category": {
-            "type": "string",
-            "description": "The item category type.",
-            "minLength": 1,
-            "maxLength": 20,
-            "enum": [
-              "DIGITAL_GOODS",
-              "PHYSICAL_GOODS",
-              "DONATION"
-            ]
+            "$ref": "#/components/schemas/item-category"
           }
         },
         "required": [
@@ -4134,12 +1773,10 @@
             "maxLength": 127
           },
           "type": {
-            "description": "The method by which the payer wants to get their items.",
-            "$ref": "#/components/schemas/shipping_type"
+            "$ref": "#/components/schemas/shipping-option-type"
           },
           "amount": {
-            "description": "The shipping cost for the selected option.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/shipping-option-amount"
           },
           "selected": {
             "type": "boolean",
@@ -4158,33 +1795,16 @@
         "title": "Shipping Details",
         "properties": {
           "name": {
-            "description": "The name of the person to whom to ship the items. Supports only the `full_name` property.",
-            "$ref": "#/components/schemas/name"
+            "$ref": "#/components/schemas/shipping-detail-name"
           },
           "type": {
-            "description": "The method by which the payer wants to get their items from the payee e.g shipping, in-person pickup. Either type or options but not both may be present.",
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "SHIPPING",
-              "PICKUP_IN_PERSON"
-            ]
+            "$ref": "#/components/schemas/shipping-detail-type"
           },
           "options": {
-            "type": "array",
-            "description": "An array of shipping options that the payee or merchant offers to the payer to ship or pick up their items.",
-            "minItems": 0,
-            "maxItems": 10,
-            "items": {
-              "description": "The option that the payee or merchant offers to the payer to ship or pick up their items.",
-              "$ref": "#/components/schemas/shipping_option"
-            }
+            "$ref": "#/components/schemas/shipping-detail-options"
           },
           "address": {
-            "description": "The address of the person to whom to ship the items. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties.",
-            "$ref": "#/components/schemas/address_portable"
+            "$ref": "#/components/schemas/shipping-detail-address"
           }
         }
       },
@@ -4201,8 +1821,7 @@
             "pattern": "^[\\w‘\\-.,\":;\\!?]*$"
           },
           "tax_total": {
-            "description": "Use this field to break down the amount of tax included in the total purchase amount. The value provided here will not add to the total purchase amount. The value can't be negative, and in most cases, it must be greater than zero in order to qualify for lower interchange rates. \n Value, by country, is:\n\n    UK. A county.\n    US. A state.\n    Canada. A province.\n    Japan. A prefecture.\n    Switzerland. A kanton.\n",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/level2-card-processing-data-tax-total"
           }
         }
       },
@@ -4215,30 +1834,7 @@
             "$ref": "#/components/schemas/item"
           },
           {
-            "properties": {
-              "commodity_code": {
-                "type": "string",
-                "description": "Code used to classify items purchased and track the total amount spent across various categories of products and services. Different corporate purchasing organizations may use different standards, but the United Nations Standard Products and Services Code (UNSPSC) is frequently used.",
-                "minLength": 1,
-                "maxLength": 12,
-                "pattern": "^[a-zA-Z0-9_'.-]*$"
-              },
-              "discount_amount": {
-                "description": "Use this field to break down the discount amount included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
-                "$ref": "#/components/schemas/money"
-              },
-              "total_amount": {
-                "description": "The subtotal for all items. Must equal the sum of (items[].unit_amount * items[].quantity) for all items. item_total.value can not be a negative number.",
-                "$ref": "#/components/schemas/money"
-              },
-              "unit_of_measure": {
-                "type": "string",
-                "description": "Unit of measure is a standard used to express the magnitude of a quantity in international trade. Most commonly used (but not limited to) examples are: Acre (ACR), Ampere (AMP), Centigram (CGM), Centimetre (CMT), Cubic inch (INQ), Cubic metre (MTQ), Fluid ounce (OZA), Foot (FOT), Hour (HUR), Item (ITM), Kilogram (KGM), Kilometre (KMT), Kilowatt (KWT), Liquid gallon (GLL), Liter (LTR), Pounds (LBS), Square foot (FTK).",
-                "minLength": 1,
-                "maxLength": 12,
-                "pattern": "^[a-zA-Z0-9_'.-]*$"
-              }
-            }
+            "$ref": "#/components/schemas/line-item-allof1"
           }
         ]
       },
@@ -4248,20 +1844,16 @@
         "description": "The level 3 card processing data collections, If your merchant account has been configured for Level 3 processing this field will be passed to the processor on your behalf. Please contact your PayPal Technical Account Manager to define level 3 data for your business.",
         "properties": {
           "shipping_amount": {
-            "description": "Use this field to break down the shipping cost included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/level3-card-processing-data-shipping-amount"
           },
           "duty_amount": {
-            "description": "Use this field to break down the duty amount included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/level3-card-processing-data-duty-amount"
           },
           "discount_amount": {
-            "description": "Use this field to break down the discount amount included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/level3-card-processing-data-discount-amount"
           },
           "shipping_address": {
-            "description": "The address of the person to whom to ship the items. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties.",
-            "$ref": "#/components/schemas/address_portable"
+            "$ref": "#/components/schemas/level3-card-processing-data-shipping-address"
           },
           "ships_from_postal_code": {
             "type": "string",
@@ -4271,13 +1863,7 @@
             "pattern": "^[a-zA-Z0-9_'.-]*$"
           },
           "line_items": {
-            "type": "array",
-            "description": "A list of the items that were purchased with this payment. If your merchant account has been configured for Level 3 processing this field will be passed to the processor on your behalf.",
-            "minItems": 1,
-            "maxItems": 100,
-            "items": {
-              "$ref": "#/components/schemas/line_item"
-            }
+            "$ref": "#/components/schemas/level3-card-processing-data-line-items"
           }
         }
       },
@@ -4300,8 +1886,7 @@
         "description": "Supplementary data about a payment. This object passes information that can be used to improve risk assessments and processing costs, for example, by providing Level 2 and Level 3 payment data.",
         "properties": {
           "card": {
-            "description": "Merchants and partners can add Level 2 and 3 data to payments to reduce risk and payment processing costs. For more information about processing payments, see <a href=\"https://developer.paypal.com/docs/checkout/advanced/processing/\">checkout</a> or <a href=\"https://developer.paypal.com/docs/multiparty/checkout/advanced/processing/\">multiparty checkout</a>.",
-            "$ref": "#/components/schemas/card_supplementary_data"
+            "$ref": "#/components/schemas/supplementary-data-card"
           }
         }
       },
@@ -4317,12 +1902,10 @@
             "maxLength": 256
           },
           "amount": {
-            "description": "The total order amount with an optional breakdown that provides details, such as the total item amount, total tax amount, shipping, handling, insurance, and discounts, if any.<br/>If you specify `amount.breakdown`, the amount equals `item_total` plus `tax_total` plus `shipping` plus `handling` plus `insurance` minus `shipping_discount` minus discount.<br/>The amount must be a positive number. The `amount.value` field supports up to 15 digits preceding the decimal. For a list of supported currencies, decimal precision, and maximum charge amount, see the PayPal REST APIs <a href=\"https://developer.paypal.com/api/rest/reference/currency-codes/\">Currency Codes</a>.",
-            "$ref": "#/components/schemas/amount_with_breakdown"
+            "$ref": "#/components/schemas/purchase-unit-request-amount"
           },
           "payee": {
-            "description": "The merchant who receives payment for this transaction.",
-            "$ref": "#/components/schemas/payee"
+            "$ref": "#/components/schemas/purchase-unit-request-payee"
           },
           "payment_instruction": {
             "$ref": "#/components/schemas/payment_instruction"
@@ -4352,20 +1935,13 @@
             "maxLength": 22
           },
           "items": {
-            "type": "array",
-            "description": "An array of items that the customer purchases from the merchant.",
-            "items": {
-              "description": "The item.",
-              "$ref": "#/components/schemas/item"
-            }
+            "$ref": "#/components/schemas/purchase-unit-request-items"
           },
           "shipping": {
-            "description": "The name and address of the person to whom to ship the items.",
-            "$ref": "#/components/schemas/shipping_detail"
+            "$ref": "#/components/schemas/purchase-unit-request-shipping"
           },
           "supplementary_data": {
-            "description": "Contains Supplementary Data.",
-            "$ref": "#/components/schemas/supplementary_data"
+            "$ref": "#/components/schemas/purchase-unit-request-supplementary-data"
           }
         },
         "required": [
@@ -4436,19 +2012,17 @@
       },
       "customer": {
         "type": "object",
-        "title": "Customer information based on PayPal's system of record",
+        "title": "PayPal's customer data records.",
         "description": "The details about a customer in PayPal's system of record.",
         "properties": {
           "id": {
             "$ref": "#/components/schemas/merchant_partner_customer_id"
           },
           "email_address": {
-            "description": "Email address of the buyer as provided to the merchant or on file with the merchant. Email Address is required if you are processing the transaction using PayPal Guest Processing which is offered to select partners and merchants. For all other use cases we do not expect partners/merchant to send email_address of their customer.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/customer-email-address"
           },
           "phone": {
-            "description": "The phone number of the buyer as provided to the merchant or on file with the merchant. The `phone.phone_number` supports only `national_number`.",
-            "$ref": "#/components/schemas/phone_with_type"
+            "$ref": "#/components/schemas/customer-phone"
           }
         }
       },
@@ -4464,7 +2038,7 @@
       },
       "vault_instruction_base": {
         "type": "object",
-        "title": "Base vault Instruction parameters",
+        "title": "Basic vault Instruction parameters",
         "description": "Basic vault instruction specification that can be extended by specific payment sources that supports vaulting.",
         "properties": {
           "store_in_vault": {
@@ -4481,8 +2055,7 @@
             "$ref": "#/components/schemas/customer"
           },
           "vault": {
-            "description": "Instruction to vault the card based on the specified strategy.",
-            "$ref": "#/components/schemas/vault_instruction_base"
+            "$ref": "#/components/schemas/card-attributes-vault"
           }
         }
       },
@@ -4492,9 +2065,7 @@
         "description": "The payment card to use to fund a payment. Can be a credit or debit card.",
         "properties": {
           "id": {
-            "description": "The PayPal-generated ID for the card.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/instrument_id"
+            "$ref": "#/components/schemas/card-id"
           },
           "name": {
             "type": "string",
@@ -4511,8 +2082,7 @@
             "maxLength": 19
           },
           "expiry": {
-            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "$ref": "#/components/schemas/date_year_month"
+            "$ref": "#/components/schemas/card-expiry"
           },
           "security_code": {
             "type": "string",
@@ -4530,26 +2100,19 @@
             "readOnly": true
           },
           "card_type": {
-            "description": "The card brand or network. Typically used in the response.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/card_brand",
-            "deprecated": true
+            "$ref": "#/components/schemas/card-card-type"
           },
           "type": {
-            "description": "The payment card type.",
-            "$ref": "#/components/schemas/card_type"
+            "$ref": "#/components/schemas/card-type"
           },
           "brand": {
-            "description": "The card brand or network. Typically used in the response.",
-            "$ref": "#/components/schemas/card_brand"
+            "$ref": "#/components/schemas/card-brand"
           },
           "billing_address": {
-            "description": "The billing address for this card. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties.",
-            "$ref": "#/components/schemas/address_portable"
+            "$ref": "#/components/schemas/card-billing-address"
           },
           "attributes": {
-            "description": "Additional attributes associated with the use of this card.",
-            "$ref": "#/components/schemas/card_attributes"
+            "$ref": "#/components/schemas/card-attributes"
           }
         }
       },
@@ -4616,8 +2179,7 @@
             "description": "The date that the transaction was authorized by the scheme. This field may not be returned for all networks. MasterCard refers to this field as \"BankNet reference date."
           },
           "network": {
-            "description": "Name of the card network through which the transaction was routed.",
-            "$ref": "#/components/schemas/card_brand"
+            "$ref": "#/components/schemas/network-transaction-reference-network"
           },
           "acquirer_reference_number": {
             "type": "string",
@@ -4682,8 +2244,7 @@
             "maxLength": 19
           },
           "expiry": {
-            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "$ref": "#/components/schemas/date_year_month"
+            "$ref": "#/components/schemas/network-token-request-expiry"
           },
           "cryptogram": {
             "type": "string",
@@ -4719,14 +2280,10 @@
         "description": "Customizes the payer experience during the 3DS Approval for payment.",
         "properties": {
           "return_url": {
-            "description": "The URL where the customer will be redirected upon successfully completing the 3DS challenge.",
-            "format": "uri",
-            "$ref": "#/components/schemas/url"
+            "$ref": "#/components/schemas/card-experience-context-return-url"
           },
           "cancel_url": {
-            "description": "The URL where the customer will be redirected upon cancelling the 3DS challenge.",
-            "format": "uri",
-            "$ref": "#/components/schemas/url"
+            "$ref": "#/components/schemas/card-experience-context-cancel-url"
           }
         }
       },
@@ -4739,22 +2296,7 @@
             "$ref": "#/components/schemas/card"
           },
           {
-            "properties": {
-              "vault_id": {
-                "description": "The PayPal-generated ID for the saved card payment source. Typically stored on the merchant's server.",
-                "$ref": "#/components/schemas/vault_id"
-              },
-              "stored_credential": {
-                "$ref": "#/components/schemas/card_stored_credential"
-              },
-              "network_token": {
-                "description": "A 3rd party network token refers to a network token that the merchant provisions from and vaults with an external TSP (Token Service Provider) other than PayPal.",
-                "$ref": "#/components/schemas/network_token_request"
-              },
-              "experience_context": {
-                "$ref": "#/components/schemas/card_experience_context"
-              }
-            }
+            "$ref": "#/components/schemas/card-request-allof1"
           }
         ]
       },
@@ -4771,14 +2313,7 @@
             "maxLength": 255
           },
           "type": {
-            "type": "string",
-            "description": "The tokenization method that generated the ID.",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[0-9A-Z_-]+$",
-            "enum": [
-              "BILLING_AGREEMENT"
-            ]
+            "$ref": "#/components/schemas/token-type"
           }
         },
         "required": [
@@ -4880,41 +2415,7 @@
             "$ref": "#/components/schemas/country_code-2"
           },
           "address_details": {
-            "type": "object",
-            "title": "Address Details",
-            "description": "The non-portable additional address details include fine-grain address information for Compliance, Risk, and other scenarios. This isn't portable with common third-party and open source applications. This can include data that is redundant with core fields. For example, `address_portable.address_line_1` is usually a combination of `address_details.street_number`, `street_name`, and `street_type`.",
-            "properties": {
-              "street_number": {
-                "type": "string",
-                "description": "The street number.",
-                "maxLength": 100
-              },
-              "street_name": {
-                "type": "string",
-                "description": "The street name. Just `Drury` in `Drury Lane`.",
-                "maxLength": 100
-              },
-              "street_type": {
-                "type": "string",
-                "description": "The street type. For example, avenue, boulevard, road, or expressway.",
-                "maxLength": 100
-              },
-              "delivery_service": {
-                "type": "string",
-                "description": "The delivery service. Post office box, bag number, or post office name.",
-                "maxLength": 100
-              },
-              "building_name": {
-                "type": "string",
-                "description": "A named locations that represents the premise. Usually a building name or number or collection of buildings with a common name or number. For example, <code>Craven House</code>.",
-                "maxLength": 100
-              },
-              "sub_building": {
-                "type": "string",
-                "description": "The first-order entity below a named building or location that represents the sub-premise. Usually a single building within a collection of buildings with a common name. Can be a flat, story, floor, room, or apartment.",
-                "maxLength": 100
-              }
-            }
+            "$ref": "#/components/schemas/address-details1"
           }
         },
         "required": [
@@ -4930,60 +2431,7 @@
             "$ref": "#/components/schemas/vault_instruction_base"
           },
           {
-            "properties": {
-              "description": {
-                "type": "string",
-                "description": "The description displayed to PayPal consumer on the approval flow for PayPal, as well as on the PayPal payment token management experience on PayPal.com.",
-                "minLength": 1,
-                "maxLength": 128
-              },
-              "usage_pattern": {
-                "type": "string",
-                "description": "Expected business/pricing model for the billing agreement.",
-                "minLength": 1,
-                "maxLength": 30,
-                "enum": [
-                  "IMMEDIATE",
-                  "DEFERRED",
-                  "RECURRING_PREPAID",
-                  "RECURRING_POSTPAID",
-                  "THRESHOLD_PREPAID",
-                  "THRESHOLD_POSTPAID"
-                ]
-              },
-              "shipping": {
-                "description": "The shipping address for the Payer.",
-                "$ref": "#/components/schemas/shipping_detail"
-              },
-              "usage_type": {
-                "type": "string",
-                "description": "The usage type associated with the PayPal payment token.",
-                "minLength": 1,
-                "maxLength": 255,
-                "pattern": "^[0-9A-Z_]+$",
-                "enum": [
-                  "MERCHANT",
-                  "PLATFORM"
-                ]
-              },
-              "customer_type": {
-                "type": "string",
-                "description": "The customer type associated with the PayPal payment token. This is to indicate whether the customer acting on the merchant / platform is either a business or a consumer.",
-                "minLength": 1,
-                "maxLength": 255,
-                "pattern": "^[0-9A-Z_]+$",
-                "default": "CONSUMER",
-                "enum": [
-                  "CONSUMER",
-                  "BUSINESS"
-                ]
-              },
-              "permit_multiple_payment_tokens": {
-                "type": "boolean",
-                "description": "Create multiple payment tokens for the same payer, merchant/platform combination. Use this when the customer has not logged in at merchant/platform. The payment token thus generated, can then also be used to create the customer account at merchant/platform. Use this also when multiple payment tokens are required for the same payer, different customer at merchant/platform. This helps to identify customers distinctly even though they may share the same PayPal account. This only applies to PayPal payment source.",
-                "default": false
-              }
-            }
+            "$ref": "#/components/schemas/vault-paypal-wallet-base-allof1"
           }
         ],
         "required": [
@@ -4999,8 +2447,7 @@
             "$ref": "#/components/schemas/customer"
           },
           "vault": {
-            "description": "Attributes used to provide the instructions during vaulting of the PayPal Wallet.",
-            "$ref": "#/components/schemas/vault_paypal_wallet_base"
+            "$ref": "#/components/schemas/paypal-wallet-attributes-vault"
           }
         }
       },
@@ -5025,68 +2472,25 @@
             "pattern": "^.*$"
           },
           "locale": {
-            "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
-            "$ref": "#/components/schemas/language"
+            "$ref": "#/components/schemas/paypal-wallet-experience-context-locale"
           },
           "shipping_preference": {
-            "type": "string",
-            "description": "The location from which the shipping address is derived.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
-            "default": "GET_FROM_FILE",
-            "enum": [
-              "GET_FROM_FILE",
-              "NO_SHIPPING",
-              "SET_PROVIDED_ADDRESS"
-            ]
+            "$ref": "#/components/schemas/shipping-address-source-location"
           },
           "return_url": {
-            "description": "The URL where the customer will be redirected upon approving a payment.",
-            "format": "uri",
-            "$ref": "#/components/schemas/url"
+            "$ref": "#/components/schemas/paypal-wallet-experience-context-return-url"
           },
           "cancel_url": {
-            "description": "The URL where the customer will be redirected upon cancelling the payment approval.",
-            "format": "uri",
-            "$ref": "#/components/schemas/url"
+            "$ref": "#/components/schemas/paypal-wallet-experience-context-cancel-url"
           },
           "landing_page": {
-            "type": "string",
-            "description": "The type of landing page to show on the PayPal site for customer checkout.",
-            "default": "NO_PREFERENCE",
-            "minLength": 1,
-            "maxLength": 13,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "LOGIN",
-              "GUEST_CHECKOUT",
-              "NO_PREFERENCE"
-            ]
+            "$ref": "#/components/schemas/paypal-wallet-experience-context-landing-page"
           },
           "user_action": {
-            "type": "string",
-            "description": "Configures a <strong>Continue</strong> or <strong>Pay Now</strong> checkout flow.",
-            "default": "CONTINUE",
-            "minLength": 1,
-            "maxLength": 8,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "CONTINUE",
-              "PAY_NOW"
-            ]
+            "$ref": "#/components/schemas/paypal-wallet-experience-context-user-action"
           },
           "payment_method_preference": {
-            "type": "string",
-            "description": "The merchant-preferred payment methods.",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[0-9A-Z_]+$",
-            "default": "UNRESTRICTED",
-            "enum": [
-              "UNRESTRICTED",
-              "IMMEDIATE_PAYMENT_REQUIRED"
-            ]
+            "$ref": "#/components/schemas/merchant-preferred-payment-methods"
           }
         }
       },
@@ -5103,36 +2507,28 @@
         "description": "A resource that identifies a PayPal Wallet is used for payment.",
         "properties": {
           "vault_id": {
-            "description": "The PayPal-generated ID for the payment_source stored within the Vault.",
-            "$ref": "#/components/schemas/vault_id"
+            "$ref": "#/components/schemas/paypal-wallet-vault-id"
           },
           "email_address": {
-            "description": "The email address of the PayPal account holder.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/paypal-wallet-email-address"
           },
           "name": {
-            "description": "The name of the PayPal account holder. Supports only the `given_name` and `surname` properties.",
-            "$ref": "#/components/schemas/name-2"
+            "$ref": "#/components/schemas/paypal-wallet-name"
           },
           "phone": {
-            "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
-            "$ref": "#/components/schemas/phone_with_type"
+            "$ref": "#/components/schemas/paypal-wallet-phone"
           },
           "birth_date": {
-            "description": "The birth date of the PayPal account holder in `YYYY-MM-DD` format.",
-            "$ref": "#/components/schemas/date_no_time"
+            "$ref": "#/components/schemas/paypal-wallet-birth-date"
           },
           "tax_info": {
-            "description": "The tax information of the PayPal account holder. Required only for Brazilian PayPal account holder's. Both `tax_id` and `tax_id_type` are required.",
-            "$ref": "#/components/schemas/tax_info"
+            "$ref": "#/components/schemas/paypal-wallet-tax-info"
           },
           "address": {
-            "description": "The address of the PayPal account holder. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
-            "$ref": "#/components/schemas/address_portable-2"
+            "$ref": "#/components/schemas/paypal-wallet-address"
           },
           "attributes": {
-            "description": "Additional attributes associated with the use of this wallet.",
-            "$ref": "#/components/schemas/paypal_wallet_attributes"
+            "$ref": "#/components/schemas/paypal-wallet-attributes"
           },
           "experience_context": {
             "$ref": "#/components/schemas/paypal_wallet_experience_context"
@@ -5161,55 +2557,36 @@
             "pattern": "^.*$"
           },
           "locale": {
-            "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
-            "$ref": "#/components/schemas/language"
+            "$ref": "#/components/schemas/experience-context-base-locale"
           },
           "shipping_preference": {
-            "type": "string",
-            "description": "The location from which the shipping address is derived.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
-            "default": "GET_FROM_FILE",
-            "enum": [
-              "GET_FROM_FILE",
-              "NO_SHIPPING",
-              "SET_PROVIDED_ADDRESS"
-            ]
+            "$ref": "#/components/schemas/experience-context-base-shipping-preference"
           },
           "return_url": {
-            "description": "The URL where the customer is redirected after the customer approves the payment.",
-            "format": "uri",
-            "$ref": "#/components/schemas/url"
+            "$ref": "#/components/schemas/experience-context-base-return-url"
           },
           "cancel_url": {
-            "description": "The URL where the customer is redirected after the customer cancels the payment.",
-            "format": "uri",
-            "$ref": "#/components/schemas/url"
+            "$ref": "#/components/schemas/experience-context-base-cancel-url"
           }
         }
       },
       "altpay_recurring_attributes_request": {},
       "bancontact_request": {
         "type": "object",
-        "title": "Bancontact payment object",
+        "title": "Bancontact Payment Information",
         "description": "Information needed to pay using Bancontact.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/bancontact-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/bancontact-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/bancontact-request-experience-context"
           },
           "attributes": {
-            "description": "Attributes for altpay recurring.",
-            "$ref": "#/components/schemas/altpay_recurring_attributes_request"
+            "$ref": "#/components/schemas/bancontact-request-attributes"
           }
         },
         "required": [
@@ -5243,19 +2620,7 @@
             "$ref": "#/components/schemas/experience_context_base"
           },
           {
-            "properties": {
-              "consumer_ip": {
-                "description": "The IP address of the consumer. It could be either IPv4 or IPv6.",
-                "$ref": "#/components/schemas/ip_address"
-              },
-              "consumer_user_agent": {
-                "type": "string",
-                "description": "The payer's User Agent. For example, Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0).",
-                "minLength": 1,
-                "maxLength": 256,
-                "pattern": "^.*$"
-              }
-            }
+            "$ref": "#/components/schemas/blik-experience-context-allof1"
           }
         ]
       },
@@ -5278,7 +2643,7 @@
       },
       "blik_one_click": {
         "type": "object",
-        "title": "BLIK one-click payment object",
+        "title": "BLIK one-click payment information",
         "description": "Information used to pay using BLIK one-click flow.",
         "properties": {
           "auth_code": {
@@ -5316,32 +2681,26 @@
       },
       "blik_request": {
         "type": "object",
-        "title": "BLIK payment object",
+        "title": "BLIK payment information",
         "description": "Information needed to pay using BLIK.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/blik-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/blik-request-country-code"
           },
           "email": {
-            "description": "The email address of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/email_address"
+            "$ref": "#/components/schemas/blik-request-email"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/blik_experience_context"
+            "$ref": "#/components/schemas/blik-request-experience-context"
           },
           "level_0": {
-            "description": "The level_0 integration flow object.",
-            "$ref": "#/components/schemas/blik_seamless"
+            "$ref": "#/components/schemas/blik-request-level0"
           },
           "one_click": {
-            "description": "The one-click integration flow object.",
-            "$ref": "#/components/schemas/blik_one_click"
+            "$ref": "#/components/schemas/blik-request-one-click"
           }
         },
         "required": [
@@ -5351,20 +2710,17 @@
       },
       "eps_request": {
         "type": "object",
-        "title": "An eps payment object",
+        "title": "An eps payment information",
         "description": "Information needed to pay using eps.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/eps-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/eps-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/eps-request-experience-context"
           }
         },
         "required": [
@@ -5374,20 +2730,17 @@
       },
       "giropay_request": {
         "type": "object",
-        "title": "A giropay payment object",
+        "title": "A giropay payment information",
         "description": "Information needed to pay using giropay.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/giropay-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/giropay-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/giropay-request-experience-context"
           }
         },
         "required": [
@@ -5405,28 +2758,23 @@
       },
       "ideal_request": {
         "type": "object",
-        "title": "The iDEAL payment object",
+        "title": "The iDEAL payment information",
         "description": "Information needed to pay using iDEAL.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/ideal-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/ideal-request-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/ideal-request-bic"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/ideal-request-experience-context"
           },
           "attributes": {
-            "description": "Attributes for altpay recurring.",
-            "$ref": "#/components/schemas/altpay_recurring_attributes_request"
+            "$ref": "#/components/schemas/ideal-request-attributes"
           }
         },
         "required": [
@@ -5436,20 +2784,17 @@
       },
       "mybank_request": {
         "type": "object",
-        "title": "MyBank payment object",
+        "title": "MyBank payment information",
         "description": "Information needed to pay using MyBank.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/mybank-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/mybank-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/mybank-request-experience-context"
           }
         },
         "required": [
@@ -5459,24 +2804,20 @@
       },
       "p24_request": {
         "type": "object",
-        "title": "P24 payment object",
+        "title": "P24 payment information",
         "description": "Information needed to pay using P24 (Przelewy24).",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/p24-request-name"
           },
           "email": {
-            "description": "The email address of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/email_address"
+            "$ref": "#/components/schemas/p24-request-email"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/p24-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/p24-request-experience-context"
           }
         },
         "required": [
@@ -5487,20 +2828,17 @@
       },
       "sofort_request": {
         "type": "object",
-        "title": "Sofort payment object",
+        "title": "Sofort payment information",
         "description": "Information needed to pay using Sofort.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/sofort-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/sofort-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/sofort-request-experience-context"
           }
         },
         "required": [
@@ -5510,20 +2848,17 @@
       },
       "trustly_request": {
         "type": "object",
-        "title": "Trustly payment object",
+        "title": "Trustly payment information",
         "description": "Information needed to pay using Trustly.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/trustly-request-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/trustly-request-country-code"
           },
           "experience_context": {
-            "description": "Customizes the payer experience during the approval process for the payment.",
-            "$ref": "#/components/schemas/experience_context_base"
+            "$ref": "#/components/schemas/trustly-request-experience-context"
           }
         },
         "required": [
@@ -5540,7 +2875,7 @@
       },
       "money-2": {
         "type": "object",
-        "title": "Money",
+        "title": "Financial Transaction Currency and Amount",
         "description": "The currency and amount for a financial transaction, such as a balance or payment due.",
         "properties": {
           "currency_code": {
@@ -5599,12 +2934,10 @@
         "description": "Information about the Payment data obtained by decrypting Apple Pay token.",
         "properties": {
           "transaction_amount": {
-            "description": "The transaction amount for the payment that the payer has approved on apple platform.",
-            "$ref": "#/components/schemas/money-2"
+            "$ref": "#/components/schemas/apple-pay-decrypted-token-data-transaction-amount"
           },
           "tokenized_card": {
-            "description": "Apple Pay tokenized credit card used to pay.",
-            "$ref": "#/components/schemas/card"
+            "$ref": "#/components/schemas/apple-pay-decrypted-token-data-tokenized-card"
           },
           "device_manufacturer_id": {
             "description": "Apple Pay Hex-encoded device manufacturer identifier. The pattern is defined by an external party and supports Unicode.",
@@ -5614,19 +2947,10 @@
             "pattern": "^.*$"
           },
           "payment_data_type": {
-            "description": "Indicates the type of payment data passed, in case of Non China the payment data is 3DSECURE and for China it is EMV.",
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 16,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "3DSECURE",
-              "EMV"
-            ]
+            "$ref": "#/components/schemas/apple-pay-decrypted-token-data-payment-data-type"
           },
           "payment_data": {
-            "description": "Apple Pay payment data object which contains the cryptogram, eci_indicator and other data.",
-            "$ref": "#/components/schemas/apple_pay_payment_data"
+            "$ref": "#/components/schemas/apple-pay-decrypted-token-data-payment-data"
           }
         },
         "required": [
@@ -5647,27 +2971,22 @@
             "pattern": "^.*$"
           },
           "name": {
-            "description": "Name on the account holder associated with apple pay.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/apple-pay-request-name"
           },
           "email_address": {
-            "description": "The email address of the account holder associated with apple pay.",
-            "$ref": "#/components/schemas/email_address"
+            "$ref": "#/components/schemas/apple-pay-request-email-address"
           },
           "phone_number": {
-            "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Supports only the `national_number` property.",
-            "$ref": "#/components/schemas/phone"
+            "$ref": "#/components/schemas/apple-pay-request-phone-number"
           },
           "decrypted_token": {
-            "description": "The decrypted payload details for the apple pay token.",
-            "$ref": "#/components/schemas/apple_pay_decrypted_token_data"
+            "$ref": "#/components/schemas/apple-pay-request-decrypted-token"
           },
           "stored_credential": {
             "$ref": "#/components/schemas/card_stored_credential"
           },
           "vault_id": {
-            "description": "The PayPal-generated ID for the saved apple pay payment_source. This ID should be stored on the merchant's server so the saved payment source can be used for future transactions.",
-            "$ref": "#/components/schemas/vault_id"
+            "$ref": "#/components/schemas/apple-pay-request-vault-id"
           },
           "attributes": {
             "$ref": "#/components/schemas/apple_pay_attributes"
@@ -5688,17 +3007,7 @@
             "pattern": "^.*$"
           },
           "shipping_preference": {
-            "type": "string",
-            "description": "The location from which the shipping address is derived.",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
-            "default": "GET_FROM_FILE",
-            "enum": [
-              "GET_FROM_FILE",
-              "NO_SHIPPING",
-              "SET_PROVIDED_ADDRESS"
-            ]
+            "$ref": "#/components/schemas/shipping-address-derive-location"
           }
         }
       },
@@ -5724,58 +3033,7 @@
             "$ref": "#/components/schemas/v3_vault_instruction_base"
           },
           {
-            "properties": {
-              "description": {
-                "type": "string",
-                "description": "The description displayed to Venmo consumer on the approval flow for Venmo, as well as on the Venmo payment token management experience on Venmo.com.",
-                "minLength": 1,
-                "maxLength": 128,
-                "pattern": "^[a-zA-Z0-9_'\\-., :;\\!?\"]*$"
-              },
-              "usage_pattern": {
-                "type": "string",
-                "description": "Expected business/pricing model for the billing agreement.",
-                "minLength": 1,
-                "maxLength": 30,
-                "pattern": "^[0-9A-Z_]+$",
-                "enum": [
-                  "IMMEDIATE",
-                  "DEFERRED",
-                  "RECURRING_PREPAID",
-                  "RECURRING_POSTPAID",
-                  "THRESHOLD_PREPAID",
-                  "THRESHOLD_POSTPAID"
-                ]
-              },
-              "usage_type": {
-                "type": "string",
-                "description": "The usage type associated with the Venmo payment token.",
-                "minLength": 1,
-                "maxLength": 255,
-                "pattern": "^[0-9A-Z_]+$",
-                "enum": [
-                  "MERCHANT",
-                  "PLATFORM"
-                ]
-              },
-              "customer_type": {
-                "type": "string",
-                "description": "The customer type associated with the Venmo payment token. This is to indicate whether the customer acting on the merchant / platform is either a business or a consumer.",
-                "minLength": 1,
-                "maxLength": 255,
-                "pattern": "^[0-9A-Z_]+$",
-                "default": "CONSUMER",
-                "enum": [
-                  "CONSUMER",
-                  "BUSINESS"
-                ]
-              },
-              "permit_multiple_payment_tokens": {
-                "type": "boolean",
-                "description": "Create multiple payment tokens for the same payer, merchant/platform combination. Use this when the customer has not logged in at merchant/platform. The payment token thus generated, can then also be used to create the customer account at merchant/platform. Use this also when multiple payment tokens are required for the same payer, different customer at merchant/platform. This helps to identify customers distinctly even though they may share the same Venmo account.",
-                "default": false
-              }
-            }
+            "$ref": "#/components/schemas/vault-venmo-wallet-base-allof1"
           }
         ],
         "required": [
@@ -5791,8 +3049,7 @@
             "$ref": "#/components/schemas/customer"
           },
           "vault": {
-            "description": "Attributes used to provide the instructions during vaulting of the Venmo Wallet.",
-            "$ref": "#/components/schemas/vault_venmo_wallet_base"
+            "$ref": "#/components/schemas/venmo-wallet-attributes-vault"
           }
         }
       },
@@ -5802,25 +3059,22 @@
         "description": "Information needed to pay using Venmo.",
         "properties": {
           "vault_id": {
-            "description": "The PayPal-generated ID for the saved Venmo wallet payment_source. This ID should be stored on the merchant's server so the saved payment source can be used for future transactions.",
-            "$ref": "#/components/schemas/vault_id"
+            "$ref": "#/components/schemas/venmo-wallet-request-vault-id"
           },
           "email_address": {
-            "description": "The email address of the payer.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/venmo-wallet-request-email-address"
           },
           "experience_context": {
             "$ref": "#/components/schemas/venmo_wallet_experience_context"
           },
           "attributes": {
-            "description": "Additional attributes associated with the use of this wallet.",
-            "$ref": "#/components/schemas/venmo_wallet_attributes"
+            "$ref": "#/components/schemas/venmo-wallet-request-attributes"
           }
         }
       },
       "payment_source": {
         "type": "object",
-        "title": "Payment Source",
+        "title": "Payment Source Definition",
         "description": "The payment source definition.",
         "properties": {
           "card": {
@@ -5830,56 +3084,43 @@
             "$ref": "#/components/schemas/token"
           },
           "paypal": {
-            "description": "Indicates that PayPal Wallet is the payment source. Main use of this selection is to provide additional instructions associated with this choice like vaulting.",
-            "$ref": "#/components/schemas/paypal_wallet"
+            "$ref": "#/components/schemas/payment-source-paypal"
           },
           "bancontact": {
-            "description": "Bancontact is the most popular online payment in Belgium. [More Details](https://www.bancontact.com/).",
-            "$ref": "#/components/schemas/bancontact_request"
+            "$ref": "#/components/schemas/payment-source-bancontact"
           },
           "blik": {
-            "description": "BLIK is a mobile payment system, created by Polish Payment Standard in order to allow millions of users to pay in shops, payout cash in ATMs and make online purchases and payments. [More Details](https://blikmobile.pl/).",
-            "$ref": "#/components/schemas/blik_request"
+            "$ref": "#/components/schemas/payment-source-blik"
           },
           "eps": {
-            "description": "The eps transfer is an online payment method developed by many Austrian banks. [More Details](https://www.eps-ueberweisung.at/).",
-            "$ref": "#/components/schemas/eps_request"
+            "$ref": "#/components/schemas/payment-source-eps"
           },
           "giropay": {
-            "description": "Giropay is an Internet payment System in Germany, based on online banking. [More Details](https://giropay.de/).",
-            "$ref": "#/components/schemas/giropay_request"
+            "$ref": "#/components/schemas/payment-source-giropay"
           },
           "ideal": {
-            "description": "The Dutch payment method iDEAL is an online payment method that enables consumers to pay online through their own bank. [More Details](https://www.ideal.nl/).",
-            "$ref": "#/components/schemas/ideal_request"
+            "$ref": "#/components/schemas/payment-source-ideal"
           },
           "mybank": {
-            "description": "MyBank is an e-authorisation solution which enables safe digital payments and identity authentication through a consumer’s own online banking portal or mobile application. [More Details](https://www.mybank.eu/).",
-            "$ref": "#/components/schemas/mybank_request"
+            "$ref": "#/components/schemas/payment-source-mybank"
           },
           "p24": {
-            "description": "P24 (Przelewy24) is a secure and fast online bank transfer service linked to all the major banks in Poland. [More Details](https://www.przelewy24.pl/).",
-            "$ref": "#/components/schemas/p24_request"
+            "$ref": "#/components/schemas/payment-source-p24"
           },
           "sofort": {
-            "description": "SOFORT Banking is a real-time bank transfer payment method that buyers use to transfer funds directly to merchants from their bank accounts. [More Details](https://www.klarna.com/sofort/).",
-            "$ref": "#/components/schemas/sofort_request"
+            "$ref": "#/components/schemas/payment-source-sofort"
           },
           "trustly": {
-            "description": "Trustly is a payment method that allows customers to shop and pay from their bank account. [More Details](https://www.trustly.net/).",
-            "$ref": "#/components/schemas/trustly_request"
+            "$ref": "#/components/schemas/payment-source-trustly"
           },
           "apple_pay": {
-            "description": "ApplePay payment source, allows buyer to pay using ApplePay, both on Web as well as on Native.",
-            "$ref": "#/components/schemas/apple_pay_request"
+            "$ref": "#/components/schemas/payment-source-apple-pay"
           },
           "google_pay": {
-            "description": "Google Pay payment source, allows buyer to pay using Google Pay.",
-            "$ref": "#/components/schemas/google_pay_request"
+            "$ref": "#/components/schemas/payment-source-google-pay"
           },
           "venmo": {
-            "description": "Information needed to indicate that Venmo is being used to fund the payment.",
-            "$ref": "#/components/schemas/venmo_wallet_request"
+            "$ref": "#/components/schemas/payment-source-venmo"
           }
         }
       },
@@ -5904,17 +3145,7 @@
             "$ref": "#/components/schemas/payee_payment_method_preference"
           },
           "standard_entry_class_code": {
-            "type": "string",
-            "description": "NACHA (the regulatory body governing the ACH network) requires that API callers (merchants, partners) obtain the consumer’s explicit authorization before initiating a transaction. To stay compliant, you’ll need to make sure that you retain a compliant authorization for each transaction that you originate to the ACH Network using this API. ACH transactions are categorized (using SEC codes) by how you capture authorization from the Receiver (the person whose bank account is being debited or credited). PayPal supports the following SEC codes.",
-            "default": "WEB",
-            "minLength": 3,
-            "maxLength": 255,
-            "enum": [
-              "TEL",
-              "WEB",
-              "CCD",
-              "PPD"
-            ]
+            "$ref": "#/components/schemas/payment-method-standard-entry-class-code"
           }
         }
       },
@@ -5953,52 +3184,19 @@
             "maxLength": 127
           },
           "locale": {
-            "description": "DEPRECATED. The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.locale`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
-            "$ref": "#/components/schemas/language"
+            "$ref": "#/components/schemas/order-application-context-locale"
           },
           "landing_page": {
-            "type": "string",
-            "description": "DEPRECATED. DEPRECATED. The type of landing page to show on the PayPal site for customer checkout.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.landing_page`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
-            "deprecated": true,
-            "default": "NO_PREFERENCE",
-            "minLength": 1,
-            "maxLength": 13,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "LOGIN",
-              "BILLING",
-              "NO_PREFERENCE"
-            ]
+            "$ref": "#/components/schemas/order-application-context-landing-page"
           },
           "shipping_preference": {
-            "type": "string",
-            "description": "DEPRECATED. DEPRECATED. The shipping preference:<ul><li>Displays the shipping address to the customer.</li><li>Enables the customer to choose an address on the PayPal site.</li><li>Restricts the customer from changing the address during the payment-approval process.</li></ul>.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.shipping_preference`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
-            "deprecated": true,
-            "default": "GET_FROM_FILE",
-            "minLength": 1,
-            "maxLength": 20,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "GET_FROM_FILE",
-              "NO_SHIPPING",
-              "SET_PROVIDED_ADDRESS"
-            ]
+            "$ref": "#/components/schemas/order-application-context-shipping-preference"
           },
           "user_action": {
-            "type": "string",
-            "description": "DEPRECATED. Configures a <strong>Continue</strong> or <strong>Pay Now</strong> checkout flow.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.user_action`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
-            "default": "CONTINUE",
-            "minLength": 1,
-            "maxLength": 8,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "CONTINUE",
-              "PAY_NOW"
-            ]
+            "$ref": "#/components/schemas/order-application-context-user-action"
           },
           "payment_method": {
-            "description": "DEPRECATED. The customer and merchant payment preferences. The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.payment_method_selected`). Please specify this field in the `experience_context` object instead of the `application_context` object..",
-            "$ref": "#/components/schemas/payment_method"
+            "$ref": "#/components/schemas/order-application-context-payment-method"
           },
           "return_url": {
             "type": "string",
@@ -6011,9 +3209,7 @@
             "description": "DEPRECATED. The URL where the customer is redirected after the customer cancels the payment. The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.cancel_url`). Please specify this field in the `experience_context` object instead of the `application_context` object."
           },
           "stored_payment_source": {
-            "$ref": "#/components/schemas/stored_payment_source",
-            "description": "DEPRECATED. Provides additional details to process a payment using a `payment_source` that has been stored or is intended to be stored (also referred to as stored_credential or card-on-file).<br/>Parameter compatibility:<br/><ul><li>`payment_type=ONE_TIME` is compatible only with `payment_initiator=CUSTOMER`.</li><li>`usage=FIRST` is compatible only with `payment_initiator=CUSTOMER`.</li><li>`previous_transaction_reference` or `previous_network_transaction_reference` is compatible only with `payment_initiator=MERCHANT`.</li><li>Only one of the parameters - `previous_transaction_reference` and `previous_network_transaction_reference` - can be present in the request.</li></ul>.  The fields in `stored_payment_source` are now available in the `stored_credential` object under the `payment_source` which supports them (eg. `payment_source.card.stored_credential.payment_initiator`). Please specify this field in the `payment_source` object instead of the `application_context` object.",
-            "deprecated": true
+            "$ref": "#/components/schemas/order-application-context-stored-payment-source"
           }
         }
       },
@@ -6026,26 +3222,16 @@
             "$ref": "#/components/schemas/checkout_payment_intent"
           },
           "payer": {
-            "description": "DEPRECATED. The customer is also known as the payer. The Payer object was intended to only be used with the `payment_source.paypal` object. In order to make this design more clear, the details in the `payer` object are now available under `payment_source.paypal`. Please use `payment_source.paypal`.",
-            "$ref": "#/components/schemas/payer",
-            "deprecated": true
+            "$ref": "#/components/schemas/order-request-payer"
           },
           "purchase_units": {
-            "type": "array",
-            "description": "An array of purchase units. Each purchase unit establishes a contract between a payer and the payee. Each purchase unit represents either a full or partial order that the payer intends to purchase from the payee.",
-            "minItems": 1,
-            "maxItems": 10,
-            "items": {
-              "description": "The purchase unit. Establishes a contract between a payer and the payee.",
-              "$ref": "#/components/schemas/purchase_unit_request"
-            }
+            "$ref": "#/components/schemas/order-request-purchase-units"
           },
           "payment_source": {
             "$ref": "#/components/schemas/payment_source"
           },
           "application_context": {
-            "description": "Customize the payer experience during the approval process for the payment with PayPal.",
-            "$ref": "#/components/schemas/order_application_context"
+            "$ref": "#/components/schemas/order-request-application-context"
           }
         },
         "required": [
@@ -6067,14 +3253,10 @@
         "title": "Transaction Date and Time Stamps",
         "properties": {
           "create_time": {
-            "description": "The date and time when the transaction occurred, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
-            "$ref": "#/components/schemas/date_time"
+            "$ref": "#/components/schemas/activity-timestamps-create-time"
           },
           "update_time": {
-            "description": "The date and time when the transaction was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "readOnly": true,
-            "$ref": "#/components/schemas/date_time"
+            "$ref": "#/components/schemas/activity-timestamps-update-time"
           }
         }
       },
@@ -6126,12 +3308,10 @@
         "description": "Results of 3D Secure Authentication.",
         "properties": {
           "authentication_status": {
-            "description": "The outcome of the issuer's authentication.",
-            "$ref": "#/components/schemas/pares_status"
+            "$ref": "#/components/schemas/3ds-auth-response-auth-status"
           },
           "enrollment_status": {
-            "description": "Status of authentication eligibility.",
-            "$ref": "#/components/schemas/enrolled"
+            "$ref": "#/components/schemas/3ds-auth-response-enrollment-status"
           }
         }
       },
@@ -6152,8 +3332,7 @@
             "$ref": "#/components/schemas/authentication_flow"
           },
           "exemption_details": {
-            "description": "Exemption details of 3D Secure Authentication.",
-            "$ref": "#/components/schemas/exemption_details"
+            "$ref": "#/components/schemas/authentication-response-exemption-details"
           }
         }
       },
@@ -6175,18 +3354,7 @@
             "description": "The [link relation type](https://tools.ietf.org/html/rfc5988#section-4), which serves as an ID for a link that unambiguously describes the semantics of the link. See [Link Relations](https://www.iana.org/assignments/link-relations/link-relations.xhtml)."
           },
           "method": {
-            "type": "string",
-            "description": "The HTTP method required to make the related call.",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "HEAD",
-              "CONNECT",
-              "OPTIONS",
-              "PATCH"
-            ]
+            "$ref": "#/components/schemas/link-description-method"
           }
         }
       },
@@ -6202,31 +3370,13 @@
             "maxLength": 255
           },
           "status": {
-            "type": "string",
-            "description": "The vault status.",
-            "minLength": 1,
-            "maxLength": 255,
-            "pattern": "^[0-9A-Z_]+$",
-            "deprecated": true,
-            "enum": [
-              "VAULTED",
-              "CREATED",
-              "APPROVED"
-            ]
+            "$ref": "#/components/schemas/vault-response-status"
           },
           "customer": {
             "$ref": "#/components/schemas/customer"
           },
           "links": {
-            "type": "array",
-            "description": "An array of request-related HATEOAS links.",
-            "readOnly": true,
-            "minItems": 1,
-            "maxItems": 10,
-            "items": {
-              "description": "A request-related [HATEOAS link](/docs/api/reference/api-responses/#hateoas-links).",
-              "$ref": "#/components/schemas/link_description"
-            }
+            "$ref": "#/components/schemas/vault-response-links"
           }
         }
       },
@@ -6246,8 +3396,7 @@
         "description": "Representation of card details as received in the request.",
         "properties": {
           "expiry": {
-            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "$ref": "#/components/schemas/date_year_month"
+            "$ref": "#/components/schemas/card-from-request-expiry"
           },
           "last_digits": {
             "type": "string",
@@ -6278,20 +3427,10 @@
             "maxLength": 64
           },
           "bin_country_code": {
-            "description": "The [two-character ISO-3166-1 country code](/docs/integration/direct/rest/country-codes/) of the bank.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/bin-details-bin-country-code"
           },
           "products": {
-            "type": "array",
-            "description": "The type of card product assigned to the BIN by the issuer. These values are defined by the issuer and may change over time. Some examples include: PREPAID_GIFT, CONSUMER, CORPORATE.",
-            "items": {
-              "type": "string",
-              "description": "This value provides the category of the BIN.",
-              "minLength": 1,
-              "maxLength": 255
-            },
-            "minItems": 1,
-            "maxItems": 256
+            "$ref": "#/components/schemas/bin-details-products"
           }
         }
       },
@@ -6313,30 +3452,13 @@
             "readOnly": true
           },
           "brand": {
-            "description": "The card brand or network. Typically used in the response.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/card_brand"
+            "$ref": "#/components/schemas/card-response-brand"
           },
           "available_networks": {
-            "type": "array",
-            "description": "Array of brands or networks associated with the card.",
-            "readOnly": true,
-            "minItems": 1,
-            "maxItems": 256,
-            "items": {
-              "$ref": "#/components/schemas/card_brand"
-            }
+            "$ref": "#/components/schemas/card-response-available-networks"
           },
           "type": {
-            "type": "string",
-            "description": "The payment card type.",
-            "readOnly": true,
-            "enum": [
-              "CREDIT",
-              "DEBIT",
-              "PREPAID",
-              "UNKNOWN"
-            ]
+            "$ref": "#/components/schemas/card-response-type"
           },
           "authentication_result": {
             "$ref": "#/components/schemas/authentication_response"
@@ -6348,12 +3470,10 @@
             "$ref": "#/components/schemas/card_from_request"
           },
           "expiry": {
-            "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "$ref": "#/components/schemas/date_year_month"
+            "$ref": "#/components/schemas/card-response-expiry"
           },
           "bin_details": {
-            "description": "Bank Identification Number (BIN) details used to fund a payment.",
-            "$ref": "#/components/schemas/bin_details"
+            "$ref": "#/components/schemas/card-response-bin-details"
           }
         }
       },
@@ -6367,7 +3487,7 @@
       },
       "phone_type-2": {
         "type": "string",
-        "title": "Phone Type",
+        "title": "Phone Type Enum",
         "description": "The phone type.",
         "enum": [
           "FAX",
@@ -6380,7 +3500,7 @@
       },
       "phone-2": {
         "type": "object",
-        "title": "Phone",
+        "title": "Canonical International Phone Number",
         "description": "The phone number in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en).",
         "properties": {
           "national_number": {
@@ -6401,24 +3521,13 @@
         "description": "Details about the merchant cobranded card used for order purchase.",
         "properties": {
           "labels": {
-            "type": "array",
-            "description": "Array of labels for the cobranded card.",
-            "minItems": 1,
-            "maxItems": 25,
-            "items": {
-              "type": "string",
-              "description": "Label for the cobranded card.",
-              "minLength": 1,
-              "maxLength": 256
-            }
+            "$ref": "#/components/schemas/cobranded-card-labels"
           },
           "payee": {
-            "description": "Merchant associated with the purchase.",
-            "$ref": "#/components/schemas/payee_base"
+            "$ref": "#/components/schemas/cobranded-card-payee"
           },
           "amount": {
-            "description": "Amount that was charged to the cobranded card.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/cobranded-card-amount"
           }
         }
       },
@@ -6431,13 +3540,7 @@
             "$ref": "#/components/schemas/vault_response"
           },
           "cobranded_cards": {
-            "type": "array",
-            "description": "An array of merchant cobranded cards used by buyer to complete an order. This array will be present if a merchant has onboarded their cobranded card with PayPal and provided corresponding label(s).",
-            "minItems": 0,
-            "maxItems": 25,
-            "items": {
-              "$ref": "#/components/schemas/cobranded_card"
-            }
+            "$ref": "#/components/schemas/paypal-wallet-attributes-response-cobranded-cards"
           }
         }
       },
@@ -6447,36 +3550,28 @@
         "description": "The PayPal Wallet response.",
         "properties": {
           "email_address": {
-            "description": "The email address of the PayPal account holder.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/paypal-wallet-response-email-address"
           },
           "account_id": {
-            "description": "The PayPal-assigned ID for the PayPal account holder.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/account_id-2"
+            "$ref": "#/components/schemas/paypal-wallet-response-account-id"
           },
           "name": {
-            "description": "The name of the PayPal account holder. Supports only the `given_name` and `surname` properties.",
-            "$ref": "#/components/schemas/name-2"
+            "$ref": "#/components/schemas/paypal-wallet-response-name"
           },
           "phone_type": {
             "$ref": "#/components/schemas/phone_type-2"
           },
           "phone_number": {
-            "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. Supports only the `national_number` property.",
-            "$ref": "#/components/schemas/phone-2"
+            "$ref": "#/components/schemas/paypal-wallet-response-phone-number"
           },
           "birth_date": {
-            "description": "The birth date of the PayPal account holder in `YYYY-MM-DD` format.",
-            "$ref": "#/components/schemas/date_no_time"
+            "$ref": "#/components/schemas/paypal-wallet-response-birth-date"
           },
           "tax_info": {
-            "description": "The tax information of the PayPal account holder. Required only for Brazilian PayPal account holder's. Both `tax_id` and `tax_id_type` are required.",
-            "$ref": "#/components/schemas/tax_info"
+            "$ref": "#/components/schemas/paypal-wallet-response-tax-info"
           },
           "address": {
-            "description": "The address of the PayPal account holder. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
-            "$ref": "#/components/schemas/address_portable-2"
+            "$ref": "#/components/schemas/paypal-wallet-response-address"
           },
           "attributes": {
             "$ref": "#/components/schemas/paypal_wallet_attributes_response"
@@ -6497,16 +3592,13 @@
         "description": "Information used to pay Bancontact.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/bancontact-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/bancontact-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/bancontact-bic"
           },
           "iban_last_chars": {
             "$ref": "#/components/schemas/iban_last_chars"
@@ -6519,8 +3611,7 @@
             "description": "The last digits of the card used to fund the Bancontact payment."
           },
           "attributes": {
-            "description": "Attributes for SEPA direct debit object.",
-            "$ref": "#/components/schemas/altpay_recurring_attributes"
+            "$ref": "#/components/schemas/bancontact-attributes"
           }
         }
       },
@@ -6544,20 +3635,16 @@
         "description": "Information used to pay using BLIK.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/blik-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/blik-country-code"
           },
           "email": {
-            "description": "The email address of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/email_address"
+            "$ref": "#/components/schemas/blik-email"
           },
           "one_click": {
-            "description": "The one-click integration flow object.",
-            "$ref": "#/components/schemas/blik_one_click_response"
+            "$ref": "#/components/schemas/blik-one-click"
           }
         }
       },
@@ -6567,16 +3654,13 @@
         "description": "Information used to pay using eps.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/eps-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/eps-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/eps-bic"
           }
         }
       },
@@ -6586,16 +3670,13 @@
         "description": "Information needed to pay using giropay.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/giropay-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/giropay-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/giropay-bic"
           }
         }
       },
@@ -6605,23 +3686,19 @@
         "description": "Information used to pay using iDEAL.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/ideal-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/ideal-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/ideal-bic"
           },
           "iban_last_chars": {
             "$ref": "#/components/schemas/iban_last_chars"
           },
           "attributes": {
-            "description": "Attributes for SEPA direct debit object.",
-            "$ref": "#/components/schemas/altpay_recurring_attributes"
+            "$ref": "#/components/schemas/ideal-attributes"
           }
         }
       },
@@ -6631,16 +3708,13 @@
         "description": "Information used to pay using MyBank.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/mybank-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/mybank-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/mybank-bic"
           },
           "iban_last_chars": {
             "$ref": "#/components/schemas/iban_last_chars"
@@ -6653,16 +3727,13 @@
         "description": "Information used to pay using P24(Przelewy24).",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/p24-name"
           },
           "email": {
-            "description": "The email address of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/email_address"
+            "$ref": "#/components/schemas/p24-email"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/p24-country-code"
           },
           "payment_descriptor": {
             "type": "string",
@@ -6690,16 +3761,13 @@
         "description": "Information used to pay using Sofort.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/sofort-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/sofort-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/sofort-bic"
           },
           "iban_last_chars": {
             "$ref": "#/components/schemas/iban_last_chars"
@@ -6712,16 +3780,13 @@
         "description": "Information needed to pay using Trustly.",
         "properties": {
           "name": {
-            "description": "The name of the account holder associated with this payment method.",
-            "$ref": "#/components/schemas/full_name"
+            "$ref": "#/components/schemas/trustly-name"
           },
           "country_code": {
-            "description": "The two-character ISO 3166-1 country code.",
-            "$ref": "#/components/schemas/country_code"
+            "$ref": "#/components/schemas/trustly-country-code"
           },
           "bic": {
-            "description": "The bank identification code (BIC).",
-            "$ref": "#/components/schemas/bic"
+            "$ref": "#/components/schemas/trustly-bic"
           },
           "iban_last_chars": {
             "$ref": "#/components/schemas/iban_last_chars"
@@ -6744,13 +3809,10 @@
         "description": "Venmo wallet response.",
         "properties": {
           "email_address": {
-            "description": "The email address of the payer.",
-            "$ref": "#/components/schemas/email"
+            "$ref": "#/components/schemas/venmo-wallet-response-email-address"
           },
           "account_id": {
-            "description": "This is an immutable system-generated id for a user's Venmo account.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/account_id-2"
+            "$ref": "#/components/schemas/venmo-wallet-response-account-id"
           },
           "user_name": {
             "description": "The Venmo user name chosen by the user, also know as a Venmo handle.",
@@ -6760,16 +3822,13 @@
             "maxLength": 50
           },
           "name": {
-            "description": "The name associated with the Venmo account. Supports only the `given_name` and `surname` properties.",
-            "$ref": "#/components/schemas/name-2"
+            "$ref": "#/components/schemas/venmo-wallet-response-name"
           },
           "phone_number": {
-            "description": "The phone number associated with the Venmo account, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Supports only the `national_number` property.",
-            "$ref": "#/components/schemas/phone-2"
+            "$ref": "#/components/schemas/venmo-wallet-response-phone-number"
           },
           "address": {
-            "description": "The address of the payer. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
-            "$ref": "#/components/schemas/address_portable-2"
+            "$ref": "#/components/schemas/venmo-wallet-response-address"
           },
           "attributes": {
             "$ref": "#/components/schemas/venmo_wallet_attributes_response"
@@ -6867,8 +3926,7 @@
             "pattern": "^(https:)([/|.|\\w|\\s|-])*\\.(?:jpg|gif|png|jpeg|JPG|GIF|PNG|JPEG)"
           },
           "upc": {
-            "description": "The Universal Product Code of the item.",
-            "$ref": "#/components/schemas/universal_product_code"
+            "$ref": "#/components/schemas/tracker-item-upc"
           }
         }
       },
@@ -6878,33 +3936,7 @@
         "description": "The tracking response on creation of tracker.",
         "allOf": [
           {
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The tracker id.",
-                "readOnly": true
-              },
-              "status": {
-                "$ref": "#/components/schemas/tracker_status"
-              },
-              "items": {
-                "type": "array",
-                "description": "An array of details of items in the shipment.",
-                "items": {
-                  "description": "Items in a shipment.",
-                  "$ref": "#/components/schemas/tracker_item"
-                }
-              },
-              "links": {
-                "type": "array",
-                "description": "An array of request-related HATEOAS links.",
-                "readOnly": true,
-                "items": {
-                  "$ref": "#/components/schemas/link_description",
-                  "description": "A request-related [HATEOAS link](/api/rest/responses/#hateoas-links)."
-                }
-              }
-            }
+            "$ref": "#/components/schemas/tracker-allof0"
           },
           {
             "$ref": "#/components/schemas/activity_timestamps"
@@ -6920,15 +3952,7 @@
             "$ref": "#/components/schemas/shipping_detail"
           },
           {
-            "properties": {
-              "trackers": {
-                "type": "array",
-                "description": "An array of trackers for a transaction.",
-                "items": {
-                  "$ref": "#/components/schemas/tracker"
-                }
-              }
-            }
+            "$ref": "#/components/schemas/shipping-with-tracking-details-allof1"
           }
         ]
       },
@@ -6938,14 +3962,7 @@
         "type": "object",
         "properties": {
           "reason": {
-            "description": "The reason why the authorized status is `PENDING`.",
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 24,
-            "pattern": "^[A-Z_]+$",
-            "enum": [
-              "PENDING_REVIEW"
-            ]
+            "$ref": "#/components/schemas/authorization-status-details-reason"
           }
         }
       },
@@ -6955,22 +3972,10 @@
         "description": "The status fields for an authorized payment.",
         "properties": {
           "status": {
-            "description": "The status for the authorized payment.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "CREATED",
-              "CAPTURED",
-              "DENIED",
-              "PARTIALLY_CAPTURED",
-              "VOIDED",
-              "PENDING"
-            ]
+            "$ref": "#/components/schemas/authorization-status-status"
           },
           "status_details": {
-            "description": "The details of the authorized order pending status.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/authorization_status_details"
+            "$ref": "#/components/schemas/authorization-status-status-details"
           }
         }
       },
@@ -6980,27 +3985,10 @@
         "title": "Seller Protection",
         "properties": {
           "status": {
-            "type": "string",
-            "description": "Indicates whether the transaction is eligible for seller protection. For information, see [PayPal Seller Protection for Merchants](https://www.paypal.com/us/webapps/mpp/security/seller-protection).",
-            "readOnly": true,
-            "enum": [
-              "ELIGIBLE",
-              "PARTIALLY_ELIGIBLE",
-              "NOT_ELIGIBLE"
-            ]
+            "$ref": "#/components/schemas/seller-protection-status"
           },
           "dispute_categories": {
-            "type": "array",
-            "description": "An array of conditions that are covered for the transaction.",
-            "items": {
-              "type": "string",
-              "description": "The condition that is covered for the transaction.",
-              "enum": [
-                "ITEM_NOT_RECEIVED",
-                "UNAUTHORIZED_TRANSACTION"
-              ]
-            },
-            "readOnly": true
+            "$ref": "#/components/schemas/seller-protection-dispute-categories"
           }
         }
       },
@@ -7013,48 +4001,7 @@
             "$ref": "#/components/schemas/authorization_status"
           },
           {
-            "properties": {
-              "id": {
-                "description": "The PayPal-generated ID for the authorized payment.",
-                "type": "string",
-                "readOnly": true
-              },
-              "amount": {
-                "description": "The amount for this authorized payment.",
-                "$ref": "#/components/schemas/money",
-                "readOnly": true
-              },
-              "invoice_id": {
-                "description": "The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.",
-                "type": "string",
-                "readOnly": true
-              },
-              "custom_id": {
-                "type": "string",
-                "description": "The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. Appears in transaction and settlement reports.",
-                "maxLength": 127
-              },
-              "network_transaction_reference": {
-                "$ref": "#/components/schemas/network_transaction_reference"
-              },
-              "seller_protection": {
-                "$ref": "#/components/schemas/seller_protection",
-                "readOnly": true
-              },
-              "expiration_time": {
-                "description": "The date and time when the authorized payment expires, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-                "$ref": "#/components/schemas/date_time",
-                "readOnly": true
-              },
-              "links": {
-                "description": "An array of related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
-                "type": "array",
-                "readOnly": true,
-                "items": {
-                  "$ref": "#/components/schemas/link_description"
-                }
-              }
-            }
+            "$ref": "#/components/schemas/authorization-allof1"
           },
           {
             "$ref": "#/components/schemas/activity_timestamps"
@@ -7067,228 +4014,16 @@
         "description": "The processor response information for payment requests, such as direct credit card transactions.",
         "properties": {
           "avs_code": {
-            "description": "The address verification code for Visa, Discover, Mastercard, or American Express transactions.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "A",
-              "B",
-              "C",
-              "D",
-              "E",
-              "F",
-              "G",
-              "I",
-              "M",
-              "N",
-              "P",
-              "R",
-              "S",
-              "U",
-              "W",
-              "X",
-              "Y",
-              "Z",
-              "Null",
-              "0",
-              "1",
-              "2",
-              "3",
-              "4"
-            ]
+            "$ref": "#/components/schemas/processor-response-avs-code"
           },
           "cvv_code": {
-            "description": "The card verification value code for for Visa, Discover, Mastercard, or American Express.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "E",
-              "I",
-              "M",
-              "N",
-              "P",
-              "S",
-              "U",
-              "X",
-              "All others",
-              "0",
-              "1",
-              "2",
-              "3",
-              "4"
-            ]
+            "$ref": "#/components/schemas/processor-response-cvv-code"
           },
           "response_code": {
-            "description": "Processor response code for the non-PayPal payment processor errors.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "0000",
-              "00N7",
-              "0100",
-              "0390",
-              "0500",
-              "0580",
-              "0800",
-              "0880",
-              "0890",
-              "0960",
-              "0R00",
-              "1000",
-              "10BR",
-              "1300",
-              "1310",
-              "1312",
-              "1317",
-              "1320",
-              "1330",
-              "1335",
-              "1340",
-              "1350",
-              "1352",
-              "1360",
-              "1370",
-              "1380",
-              "1382",
-              "1384",
-              "1390",
-              "1393",
-              "5100",
-              "5110",
-              "5120",
-              "5130",
-              "5135",
-              "5140",
-              "5150",
-              "5160",
-              "5170",
-              "5180",
-              "5190",
-              "5200",
-              "5210",
-              "5400",
-              "5500",
-              "5650",
-              "5700",
-              "5710",
-              "5800",
-              "5900",
-              "5910",
-              "5920",
-              "5930",
-              "5950",
-              "6300",
-              "7600",
-              "7700",
-              "7710",
-              "7800",
-              "7900",
-              "8000",
-              "8010",
-              "8020",
-              "8030",
-              "8100",
-              "8110",
-              "8220",
-              "9100",
-              "9500",
-              "9510",
-              "9520",
-              "9530",
-              "9540",
-              "9600",
-              "PCNR",
-              "PCVV",
-              "PP06",
-              "PPRN",
-              "PPAD",
-              "PPAB",
-              "PPAE",
-              "PPAG",
-              "PPAI",
-              "PPAR",
-              "PPAU",
-              "PPAV",
-              "PPAX",
-              "PPBG",
-              "PPC2",
-              "PPCE",
-              "PPCO",
-              "PPCR",
-              "PPCT",
-              "PPCU",
-              "PPD3",
-              "PPDC",
-              "PPDI",
-              "PPDV",
-              "PPDT",
-              "PPEF",
-              "PPEL",
-              "PPER",
-              "PPEX",
-              "PPFE",
-              "PPFI",
-              "PPFR",
-              "PPFV",
-              "PPGR",
-              "PPH1",
-              "PPIF",
-              "PPII",
-              "PPIM",
-              "PPIT",
-              "PPLR",
-              "PPLS",
-              "PPMB",
-              "PPMC",
-              "PPMD",
-              "PPNC",
-              "PPNL",
-              "PPNM",
-              "PPNT",
-              "PPPH",
-              "PPPI",
-              "PPPM",
-              "PPQC",
-              "PPRE",
-              "PPRF",
-              "PPRR",
-              "PPS0",
-              "PPS1",
-              "PPS2",
-              "PPS3",
-              "PPS4",
-              "PPS5",
-              "PPS6",
-              "PPSC",
-              "PPSD",
-              "PPSE",
-              "PPTE",
-              "PPTF",
-              "PPTI",
-              "PPTR",
-              "PPTT",
-              "PPTV",
-              "PPUA",
-              "PPUC",
-              "PPUE",
-              "PPUI",
-              "PPUP",
-              "PPUR",
-              "PPVC",
-              "PPVE",
-              "PPVT"
-            ]
+            "$ref": "#/components/schemas/processor-response-response-code"
           },
           "payment_advice_code": {
-            "description": "The declined payment transactions might have payment advice codes. The card networks, like Visa and Mastercard, return payment advice codes.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "01",
-              "02",
-              "03",
-              "21"
-            ]
+            "$ref": "#/components/schemas/processor-response-payment-advice-code"
           }
         }
       },
@@ -7301,13 +4036,7 @@
             "$ref": "#/components/schemas/authorization"
           },
           {
-            "properties": {
-              "processor_response": {
-                "$ref": "#/components/schemas/processor_response",
-                "description": "The processor response for card transactions.",
-                "readOnly": true
-              }
-            }
+            "$ref": "#/components/schemas/authorization-with-additional-data-allof1"
           }
         ]
       },
@@ -7317,24 +4046,7 @@
         "type": "object",
         "properties": {
           "reason": {
-            "description": "The reason why the captured payment status is `PENDING` or `DENIED`.",
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 64,
-            "pattern": "^[A-Z_]+$",
-            "enum": [
-              "BUYER_COMPLAINT",
-              "CHARGEBACK",
-              "ECHECK",
-              "INTERNATIONAL_WITHDRAWAL",
-              "OTHER",
-              "PENDING_REVIEW",
-              "RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION",
-              "REFUNDED",
-              "TRANSACTION_APPROVED_AWAITING_FUNDING",
-              "UNILATERAL",
-              "VERIFICATION_REQUIRED"
-            ]
+            "$ref": "#/components/schemas/capture-status-details-reason"
           }
         }
       },
@@ -7344,22 +4056,10 @@
         "description": "The status of a captured payment.",
         "properties": {
           "status": {
-            "description": "The status of the captured payment.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "COMPLETED",
-              "DECLINED",
-              "PARTIALLY_REFUNDED",
-              "PENDING",
-              "REFUNDED",
-              "FAILED"
-            ]
+            "$ref": "#/components/schemas/capture-status-status"
           },
           "status_details": {
-            "description": "The details of the captured payment status.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/capture_status_details"
+            "$ref": "#/components/schemas/capture-status-status-details"
           }
         }
       },
@@ -7369,12 +4069,10 @@
         "title": "Exchange Rate",
         "properties": {
           "source_currency": {
-            "description": "The source currency from which to convert an amount.",
-            "$ref": "#/components/schemas/currency_code"
+            "$ref": "#/components/schemas/exchange-rate-source-currency"
           },
           "target_currency": {
-            "description": "The target currency to which to convert an amount.",
-            "$ref": "#/components/schemas/currency_code"
+            "$ref": "#/components/schemas/exchange-rate-target-currency"
           },
           "value": {
             "description": "The target currency amount. Equivalent to one unit of the source currency. Formatted as integer or decimal value with one to 15 digits to the right of the decimal point.",
@@ -7389,37 +4087,25 @@
         "description": "The detailed breakdown of the capture activity. This is not available for transactions that are in pending state.",
         "properties": {
           "gross_amount": {
-            "description": "The amount for this captured payment in the currency of the transaction.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/seller-receivable-breakdown-gross-amount"
           },
           "paypal_fee": {
-            "description": "The applicable fee for this captured payment in the currency of the transaction.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/seller-receivable-breakdown-paypal-fee"
           },
           "paypal_fee_in_receivable_currency": {
-            "description": "The applicable fee for this captured payment in the receivable currency. Returned only in cases the fee is charged in the receivable currency. Example 'CNY'.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/captured-payment-fee-receivable-currency"
           },
           "net_amount": {
-            "description": "The net amount that the payee receives for this captured payment in their PayPal account. The net amount is computed as <code>gross_amount</code> minus the <code>paypal_fee</code> minus the <code>platform_fees</code>.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/seller-receivable-breakdown-net-amount"
           },
           "receivable_amount": {
-            "description": "The net amount that is credited to the payee's PayPal account. Returned only when the currency of the captured payment is different from the currency of the PayPal account where the payee wants to credit the funds. The amount is computed as <code>net_amount</code> times <code>exchange_rate</code>.",
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/seller-receivable-breakdown-receivable-amount"
           },
           "exchange_rate": {
-            "description": "The exchange rate that determines the amount that is credited to the payee's PayPal account. Returned when the currency of the captured payment is different from the currency of the PayPal account where the payee wants to credit the funds.",
-            "$ref": "#/components/schemas/exchange_rate"
+            "$ref": "#/components/schemas/seller-receivable-breakdown-exchange-rate"
           },
           "platform_fees": {
-            "type": "array",
-            "description": "An array of platform or partner fees, commissions, or brokerage fees that associated with the captured payment.",
-            "minItems": 0,
-            "maxItems": 1,
-            "items": {
-              "$ref": "#/components/schemas/platform_fee"
-            }
+            "$ref": "#/components/schemas/seller-receivable-breakdown-platform-fees"
           }
         },
         "required": [
@@ -7435,60 +4121,7 @@
             "$ref": "#/components/schemas/capture_status"
           },
           {
-            "properties": {
-              "id": {
-                "description": "The PayPal-generated ID for the captured payment.",
-                "type": "string",
-                "readOnly": true
-              },
-              "amount": {
-                "description": "The amount for this captured payment.",
-                "$ref": "#/components/schemas/money",
-                "readOnly": true
-              },
-              "invoice_id": {
-                "description": "The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.",
-                "type": "string",
-                "readOnly": true
-              },
-              "custom_id": {
-                "type": "string",
-                "description": "The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. Appears in transaction and settlement reports.",
-                "maxLength": 127
-              },
-              "network_transaction_reference": {
-                "$ref": "#/components/schemas/network_transaction_reference"
-              },
-              "seller_protection": {
-                "$ref": "#/components/schemas/seller_protection",
-                "readOnly": true
-              },
-              "final_capture": {
-                "description": "Indicates whether you can make additional captures against the authorized payment. Set to `true` if you do not intend to capture additional payments against the authorization. Set to `false` if you intend to capture additional payments against the authorization.",
-                "type": "boolean",
-                "default": false,
-                "readOnly": true
-              },
-              "seller_receivable_breakdown": {
-                "$ref": "#/components/schemas/seller_receivable_breakdown",
-                "readOnly": true
-              },
-              "disbursement_mode": {
-                "$ref": "#/components/schemas/disbursement_mode"
-              },
-              "links": {
-                "description": "An array of related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
-                "type": "array",
-                "readOnly": true,
-                "items": {
-                  "$ref": "#/components/schemas/link_description"
-                }
-              },
-              "processor_response": {
-                "description": "An object that provides additional processor information for a direct credit card transaction.",
-                "$ref": "#/components/schemas/processor_response"
-              }
-            }
+            "$ref": "#/components/schemas/capture-allof1"
           },
           {
             "$ref": "#/components/schemas/activity_timestamps"
@@ -7501,11 +4134,7 @@
         "type": "object",
         "properties": {
           "reason": {
-            "description": "The reason why the refund has the `PENDING` or `FAILED` status.",
-            "type": "string",
-            "enum": [
-              "ECHECK"
-            ]
+            "$ref": "#/components/schemas/refund-status-details-reason"
           }
         }
       },
@@ -7515,20 +4144,10 @@
         "title": "Refund Status",
         "properties": {
           "status": {
-            "description": "The status of the refund.",
-            "type": "string",
-            "readOnly": true,
-            "enum": [
-              "CANCELLED",
-              "FAILED",
-              "PENDING",
-              "COMPLETED"
-            ]
+            "$ref": "#/components/schemas/refund-status-status"
           },
           "status_details": {
-            "description": "The details of the refund status.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/refund_status_details"
+            "$ref": "#/components/schemas/refund-status-status-details"
           }
         }
       },
@@ -7538,19 +4157,13 @@
         "description": "The net amount. Returned when the currency of the refund is different from the currency of the PayPal account where the merchant holds their funds.",
         "properties": {
           "payable_amount": {
-            "description": "The net amount debited from the merchant's PayPal account.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/net-amount-breakdown-item-payable-amount"
           },
           "converted_amount": {
-            "description": "The converted payable amount.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/money"
+            "$ref": "#/components/schemas/net-amount-breakdown-item-converted-amount"
           },
           "exchange_rate": {
-            "description": "The exchange rate that determines the amount that was debited from the merchant's PayPal account.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/exchange_rate"
+            "$ref": "#/components/schemas/net-amount-breakdown-item-exchange-rate"
           }
         }
       },
@@ -7563,109 +4176,7 @@
             "$ref": "#/components/schemas/refund_status"
           },
           {
-            "properties": {
-              "id": {
-                "description": "The PayPal-generated ID for the refund.",
-                "type": "string",
-                "readOnly": true
-              },
-              "amount": {
-                "description": "The amount that the payee refunded to the payer.",
-                "$ref": "#/components/schemas/money",
-                "readOnly": true
-              },
-              "invoice_id": {
-                "description": "The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.",
-                "type": "string",
-                "readOnly": true
-              },
-              "custom_id": {
-                "type": "string",
-                "description": "The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. Appears in transaction and settlement reports.",
-                "minLength": 1,
-                "maxLength": 127,
-                "pattern": "^[A-Za-z0-9-_.,]*$"
-              },
-              "acquirer_reference_number": {
-                "type": "string",
-                "description": "Reference ID issued for the card transaction. This ID can be used to track the transaction across processors, card brands and issuing banks.",
-                "minLength": 1,
-                "maxLength": 36,
-                "pattern": "^[a-zA-Z0-9]+$"
-              },
-              "note_to_payer": {
-                "description": "The reason for the refund. Appears in both the payer's transaction history and the emails that the payer receives.",
-                "type": "string",
-                "readOnly": true
-              },
-              "seller_payable_breakdown": {
-                "description": "The breakdown of the refund.",
-                "type": "object",
-                "title": "Merchant Payable Breakdown",
-                "properties": {
-                  "gross_amount": {
-                    "description": "The amount that the payee refunded to the payer.",
-                    "$ref": "#/components/schemas/money",
-                    "readOnly": true
-                  },
-                  "paypal_fee": {
-                    "description": "The PayPal fee that was refunded to the payer in the currency of the transaction. This fee might not match the PayPal fee that the payee paid when the payment was captured.",
-                    "$ref": "#/components/schemas/money",
-                    "readOnly": true
-                  },
-                  "paypal_fee_in_receivable_currency": {
-                    "description": "The PayPal fee that was refunded to the payer in the receivable currency. Returned only in cases when the receivable currency is different from transaction currency. Example 'CNY'.",
-                    "$ref": "#/components/schemas/money",
-                    "readOnly": true
-                  },
-                  "net_amount": {
-                    "description": "The net amount that the payee's account is debited in the transaction currency. The net amount is calculated as <code>gross_amount</code> minus <code>paypal_fee</code> minus <code>platform_fees</code>.",
-                    "$ref": "#/components/schemas/money",
-                    "readOnly": true
-                  },
-                  "net_amount_in_receivable_currency": {
-                    "description": "The net amount that the payee's account is debited in the receivable currency. Returned only in cases when the receivable currency is different from transaction currency. Example 'CNY'.",
-                    "$ref": "#/components/schemas/money",
-                    "readOnly": true
-                  },
-                  "platform_fees": {
-                    "type": "array",
-                    "description": "An array of platform or partner fees, commissions, or brokerage fees for the refund.",
-                    "minItems": 0,
-                    "maxItems": 1,
-                    "items": {
-                      "$ref": "#/components/schemas/platform_fee"
-                    }
-                  },
-                  "net_amount_breakdown": {
-                    "type": "array",
-                    "description": "An array of breakdown values for the net amount. Returned when the currency of the refund is different from the currency of the PayPal account where the payee holds their funds.",
-                    "items": {
-                      "$ref": "#/components/schemas/net_amount_breakdown_item"
-                    },
-                    "readOnly": true
-                  },
-                  "total_refunded_amount": {
-                    "description": "The total amount refunded from the original capture to date. For example, if a payer makes a $100 purchase and was refunded $20 a week ago and was refunded $30 in this refund, the `gross_amount` is $30 for this refund and the `total_refunded_amount` is $50.",
-                    "$ref": "#/components/schemas/money"
-                  }
-                },
-                "readOnly": true
-              },
-              "payer": {
-                "description": "The details associated with the merchant for this transaction.",
-                "$ref": "#/components/schemas/payee_base",
-                "readOnly": true
-              },
-              "links": {
-                "description": "An array of related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
-                "type": "array",
-                "readOnly": true,
-                "items": {
-                  "$ref": "#/components/schemas/link_description"
-                }
-              }
-            }
+            "$ref": "#/components/schemas/refund-allof1"
           },
           {
             "$ref": "#/components/schemas/activity_timestamps"
@@ -7678,28 +4189,13 @@
         "description": "The collection of payments, or transactions, for a purchase unit in an order. For example, authorized payments, captured payments, and refunds.",
         "properties": {
           "authorizations": {
-            "type": "array",
-            "description": "An array of authorized payments for a purchase unit. A purchase unit can have zero or more authorized payments.",
-            "items": {
-              "description": "The authorized payment for a purchase unit.",
-              "$ref": "#/components/schemas/authorization_with_additional_data"
-            }
+            "$ref": "#/components/schemas/payment-collection-authorizations"
           },
           "captures": {
-            "type": "array",
-            "description": "An array of captured payments for a purchase unit. A purchase unit can have zero or more captured payments.",
-            "items": {
-              "description": "The captured payment for a purchase unit.",
-              "$ref": "#/components/schemas/capture"
-            }
+            "$ref": "#/components/schemas/payment-collection-captures"
           },
           "refunds": {
-            "type": "array",
-            "description": "An array of refunds for a purchase unit. A purchase unit can have zero or more refunds.",
-            "items": {
-              "description": "A refund for a purchase unit.",
-              "$ref": "#/components/schemas/refund"
-            }
+            "$ref": "#/components/schemas/payment-collection-refunds"
           }
         }
       },
@@ -7718,8 +4214,7 @@
             "$ref": "#/components/schemas/amount_with_breakdown"
           },
           "payee": {
-            "description": "The merchant who receives payment for this transaction.",
-            "$ref": "#/components/schemas/payee"
+            "$ref": "#/components/schemas/purchase-unit-payee"
           },
           "payment_instruction": {
             "$ref": "#/components/schemas/payment_instruction"
@@ -7755,25 +4250,16 @@
             "maxLength": 22
           },
           "items": {
-            "type": "array",
-            "description": "An array of items that the customer purchases from the merchant.",
-            "items": {
-              "description": "An item.",
-              "$ref": "#/components/schemas/item"
-            }
+            "$ref": "#/components/schemas/purchase-unit-items"
           },
           "shipping": {
-            "description": "The shipping address and method.",
-            "$ref": "#/components/schemas/shipping_with_tracking_details"
+            "$ref": "#/components/schemas/purchase-unit-shipping"
           },
           "supplementary_data": {
-            "description": "Supplementary data about this payment. Merchants and partners can add Level 2 and 3 data to payments to reduce risk and payment processing costs. For more information about processing payments, see <a href=\"https://developer.paypal.com/docs/checkout/advanced/processing/\">checkout</a> or <a href=\"https://developer.paypal.com/docs/multiparty/checkout/advanced/processing/\">multiparty checkout</a>.",
-            "$ref": "#/components/schemas/supplementary_data"
+            "$ref": "#/components/schemas/purchase-unit-supplementary-data"
           },
           "payments": {
-            "description": "The comprehensive history of payments for the purchase unit.",
-            "readOnly": true,
-            "$ref": "#/components/schemas/payment_collection"
+            "$ref": "#/components/schemas/purchase-unit-payments"
           }
         }
       },
@@ -7802,50 +4288,7 @@
             "$ref": "#/components/schemas/activity_timestamps"
           },
           {
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The ID of the order.",
-                "readOnly": true
-              },
-              "payment_source": {
-                "$ref": "#/components/schemas/payment_source_response"
-              },
-              "intent": {
-                "$ref": "#/components/schemas/checkout_payment_intent"
-              },
-              "processing_instruction": {
-                "$ref": "#/components/schemas/processing_instruction"
-              },
-              "payer": {
-                "$ref": "#/components/schemas/payer",
-                "description": "DEPRECATED. The customer is also known as the payer. The Payer object was intended to only be used with the `payment_source.paypal` object. In order to make this design more clear, the details in the `payer` object are now available under `payment_source.paypal`. Please use `payment_source.paypal`.",
-                "deprecated": true
-              },
-              "purchase_units": {
-                "type": "array",
-                "description": "An array of purchase units. Each purchase unit establishes a contract between a customer and merchant. Each purchase unit represents either a full or partial order that the customer intends to purchase from the merchant.",
-                "minItems": 1,
-                "maxItems": 10,
-                "items": {
-                  "$ref": "#/components/schemas/purchase_unit",
-                  "description": "A purchase unit. Establishes a contract between a customer and merchant."
-                }
-              },
-              "status": {
-                "$ref": "#/components/schemas/order_status",
-                "readOnly": true
-              },
-              "links": {
-                "type": "array",
-                "description": "An array of request-related HATEOAS links. To complete payer approval, use the `approve` link to redirect the payer. The API caller has 3 hours (default setting, this which can be changed by your account manager to 24/48/72 hours to accommodate your use case) from the time the order is created, to redirect your payer. Once redirected, the API caller has 3 hours for the payer to approve the order and either authorize or capture the order. If you are not using the PayPal JavaScript SDK to initiate PayPal Checkout (in context) ensure that you include `application_context.return_url` is specified or you will get \"We're sorry, Things don't appear to be working at the moment\" after the payer approves the payment.",
-                "readOnly": true,
-                "items": {
-                  "$ref": "#/components/schemas/link_description",
-                  "description": "A request-related [HATEOAS link](/api/rest/responses/#hateoas-links). To complete payer approval, use the `approve` link with the `GET` method."
-                }
-              }
-            }
+            "$ref": "#/components/schemas/order-allof1"
           }
         ]
       },
@@ -7855,16 +4298,7 @@
         "description": "The JSON patch object to apply partial updates to resources.",
         "properties": {
           "op": {
-            "type": "string",
-            "description": "The operation.",
-            "enum": [
-              "add",
-              "remove",
-              "replace",
-              "move",
-              "copy",
-              "test"
-            ]
+            "$ref": "#/components/schemas/patch-op"
           },
           "path": {
             "type": "string",
@@ -7894,821 +4328,14 @@
       "orders.patch-400": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "FIELD_NOT_PATCHABLE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "FIELD_NOT_PATCHABLE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Field cannot be patched."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_ARRAY_MAX_ITEMS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_ARRAY_MAX_ITEMS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The number of items in an array parameter is too large."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_SYNTAX",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_SYNTAX"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field does not conform to the expected format."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required field / parameter is missing."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AMOUNT_NOT_PATCHABLE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AMOUNT_NOT_PATCHABLE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The amount cannot be updated as the 'payer' has chosen and approved a specific financing offer for a given amount. Please Create a new Order with the updated Order amount and have the 'payer' approve the new payment terms."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PATCH_OPERATION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PATCH_OPERATION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The operation cannot be honored. Cannot add a property that's already present, use replace. Cannot remove a property thats not present, use add. Cannot replace a property thats not present, use add."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MALFORMED_REQUEST_JSON",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MALFORMED_REQUEST_JSON"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request JSON is not well formed."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-patch400-issues"
           }
         }
       },
       "orders.patch-422": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANNOT_BE_NEGATIVE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANNOT_BE_NEGATIVE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Must be greater than or equal to 0. If the currency supports decimals, only two decimal place precision is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANNOT_BE_ZERO_OR_NEGATIVE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANNOT_BE_ZERO_OR_NEGATIVE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Must be greater than zero. If the currency supports decimals, only two decimal place precision is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CITY_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CITY_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified country requires a city (address.admin_area_2)."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DECIMAL_PRECISION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DECIMAL_PRECISION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If the currency supports decimals, only two decimal place precision is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DONATION_ITEMS_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DONATION_ITEMS_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If 'purchase_unit' has \"DONATION\" as the 'items.category' then the Order can at most have one purchase_unit. Multiple purchase_units are not supported if either of them have at least one items with category as \"DONATION\"."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DUPLICATE_REFERENCE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DUPLICATE_REFERENCE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`reference_id` must be unique if multiple `purchase_unit` are provided."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_CURRENCY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_CURRENCY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Currency code is invalid or is not currently supported. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_TOTAL_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_TOTAL_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should equal sum of (unit_amount * quantity) across all items for a given purchase_unit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_TOTAL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_TOTAL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If item details are specified (items.unit_amount and items.quantity) corresponding amount.breakdown.item_total is required."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MAX_VALUE_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MAX_VALUE_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should be less than or equal to 999999999999999.99."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_JSON_POINTER_FORMAT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_JSON_POINTER_FORMAT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Path should be a valid JSON Pointer https://tools.ietf.org/html/rfc6901 that references a location within the request where the operation is performed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cannot be specified as part of the request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_PATCHABLE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_PATCHABLE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cannot be patched."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TAX_TOTAL_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TAX_TOTAL_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Should equal sum of (tax * quantity) across all items for a given purchase_unit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TAX_TOTAL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TAX_TOTAL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If item details are specified (items.tax_total and items.quantity) corresponding amount.breakdown.tax_total is required."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_INTENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_INTENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`intent=AUTHORIZE` is not supported for multiple purchase units. Only `intent=CAPTURE` is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_PATCH_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_PATCH_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value specified for this field is not currently supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PATCH_VALUE_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PATCH_VALUE_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Please specify a 'value' to for the field that is being patched."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PATCH_PATH_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PATCH_PATH_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Please specify a 'path' for the field for which the operation needs to be performed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_ACCOUNT_LOCKED_OR_CLOSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_ACCOUNT_LOCKED_OR_CLOSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The merchant account is locked or closed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_ACCOUNT_RESTRICTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_ACCOUNT_RESTRICTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The merchant account is restricted."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_FX_RATE_ID_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_FX_RATE_ID_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified FX Rate ID is for a currency that does not match with the currency of this request. Please specify a different FX Rate ID and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_FX_RATE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_FX_RATE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specific FX Rate ID is not valid. This could be either because we are not able to look up the FX Rate based on this ID or it could be because the ID belongs to another API Caller."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PLATFORM_FEES_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PLATFORM_FEES_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller is not enabled to process transactions by specifying 'platform_fees'. Please work with your PayPal Account Manager to enable this option for your account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PLATFORM_FEES_ACCOUNT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PLATFORM_FEES_ACCOUNT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified platform_fees payee account is either invalid or account setup is incomplete.Please work with your PayPal Account Manager to enable this option for your account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PLATFORM_FEES_AMOUNT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PLATFORM_FEES_AMOUNT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The platform_fees amount cannot be greater than order amount."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "POSTAL_CODE_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "POSTAL_CODE_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified country requires a postal code."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REFERENCE_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REFERENCE_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Filter expression value is incorrect. Please check the value of the reference_id and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REFERENCE_ID_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REFERENCE_ID_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "'reference_id' is required for each 'purchase_unit' if multiple 'purchase_unit' are provided."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTI_CURRENCY_ORDER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTI_CURRENCY_ORDER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Multiple differing values of currency_code are not supported. Entire Order request must have the same currency_code."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_OPTION_NOT_SELECTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_OPTION_NOT_SELECTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "At least one of the shipping.option should be set to 'selected = true'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_OPTIONS_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_OPTIONS_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Shipping options are not supported when 'application_context.shipping_preference' is set as 'NO_SHIPPING' or 'SET_PROVIDED_ADDRESS'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MULTIPLE_SHIPPING_OPTION_SELECTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MULTIPLE_SHIPPING_OPTION_SELECTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Only one shipping.option can be set to 'selected = true'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_ALREADY_COMPLETED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_ALREADY_COMPLETED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The order cannot be patched after it is completed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The amount provided in the preferred shipping option should match the amount provided in amount breakdown"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AMOUNT_CHANGE_NOT_ALLOWED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AMOUNT_CHANGE_NOT_ALLOWED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The amount specified is different from the amount authorized by payer."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-patch422-issues"
           }
         }
       },
@@ -8724,8 +4351,7 @@
             "maxLength": 127
           },
           "locale": {
-            "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
-            "$ref": "#/components/schemas/language"
+            "$ref": "#/components/schemas/order-confirm-application-context-locale"
           },
           "return_url": {
             "type": "string",
@@ -8767,1110 +4393,14 @@
       "orders.confirm-400": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_PARAMETER_SYNTAX",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_SYNTAX"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of the field does not conform to the expected format."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A parameter value is not valid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required field / parameter is missing"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_MAX_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_MAX_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is too long."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MALFORMED_REQUEST_JSON",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MALFORMED_REQUEST_JSON"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request JSON is not well formed."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-confirm400-issues"
           }
         }
       },
       "orders.confirm-422": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "ORDER_ALREADY_CAPTURED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_ALREADY_CAPTURED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order already captured. If 'intent=CAPTURE' only one capture per order is allowed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_ALREADY_AUTHORIZED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_ALREADY_AUTHORIZED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order already captured. If 'intent=CAPTURE' only one capture per order is allowed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_CANNOT_BE_CONFIRMED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_CANNOT_BE_CONFIRMED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "An order with status = 'COMPLETED' cannot be confirmed again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_PREVIOUS_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_PREVIOUS_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_CRYPTOGRAM",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_CRYPTOGRAM"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is mandatory for any customer initiated network token transactions."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CURRENCY_NOT_SUPPORTED_FOR_COUNTRY",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CURRENCY_NOT_SUPPORTED_FOR_COUNTRY"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        " For the payment_source specified, the currency of the Order is restricted by the country in which the payee account is based. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card is expired"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_TYPE_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_TYPE_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Processing of this card type is not supported. Use another card type."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CURRENCY_NOT_SUPPORTED_FOR_CARD_TYPE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CURRENCY_NOT_SUPPORTED_FOR_CARD_TYPE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The issued currency code of this card is not supported for direct card payments. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ONLY_ONE_PAYMENT_SOURCE_ALLOWED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ONLY_ONE_PAYMENT_SOURCE_ALLOWED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "More than one payment method within the payment source is not supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NO_PAYMENT_SOURCE_PROVIDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NO_PAYMENT_SOURCE_PROVIDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "At least one payment method is required within the payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_ALREADY_APPROVED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_ALREADY_APPROVED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payment has already been approved.  Please capture the order, or create and confirm a new order with this payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_PROCESSING_INSTRUCTION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_PROCESSING_INSTRUCTION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified processing_instruction is not supported for the given payment_source. Please refer to https://developer.paypal.com/api/orders/v2/#definition-processing_instruction for the list of payment_source that can be specified with this value."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_COMPLETE_ON_PAYMENT_APPROVAL",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_COMPLETE_ON_PAYMENT_APPROVAL"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A processing_instruction of `ORDER_COMPLETE_ON_PAYMENT_APPROVAL` is required for the specified payment_source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_EXPIRY_DATE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_EXPIRY_DATE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Expiry date is invalid. Expiry date should be a date in future and within the threshold for the payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TOKEN_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TOKEN_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The token is expired and cannot be used for payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_GOOGLE_PAY_TOKEN",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_GOOGLE_PAY_TOKEN"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The google pay token is invalid. PayPal was not able to decrypt the googlepay token or PayPal was not able to find the necessary data in the token after decryption."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The gateway merchant ID in Google Pay token is not valid. This could be because the gateway merchant Id that was authorized by payer/buyer on Google Pay does not match with the API caller of the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CRYPTOGRAM_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CRYPTOGRAM_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ONE_OF_PARAMETERS_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ONE_OF_PARAMETERS_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "One or more field is required to continue with this request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "RETURN_URL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "RETURN_URL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The return url is required when attempting to vault this source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANCEL_URL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANCEL_URL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The cancel url is required when attempting to vault this source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "COUNTRY_NOT_SUPPORTED_BY_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "COUNTRY_NOT_SUPPORTED_BY_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Country code provided is not supported by the provided payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REQUIRED_PARAMETER_FOR_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REQUIRED_PARAMETER_FOR_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The parameter is required for provided payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided payment source does not support provided item category."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The combination of the payment_source name, billing address, shipping name and shipping address could not be verified. Please correct this information and try again by creating a new order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided payment source is declined by the processor. Please try again with a different payment source by creating a new order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_CANNOT_BE_USED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_CANNOT_BE_USED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided payment source cannot be used to pay for the order. Please try again with a different payment source by creating a new order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SETUP_ERROR_FOR_BANK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SETUP_ERROR_FOR_BANK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller account setup, for bank payments, is incomplete or incorrect. Please contact your PayPal account manager."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BANK_NOT_SUPPORTED_FOR_VERIFICATION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BANK_NOT_SUPPORTED_FOR_VERIFICATION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Verification for this bank account is not supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "APPLE_PAY_AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "APPLE_PAY_AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ONE_OF_THE_PARAMETERS_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ONE_OF_THE_PARAMETERS_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "One or more field is required to continue with this request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_ADDRESS_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_ADDRESS_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided billing address is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_ADDRESS_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_ADDRESS_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided shipping address is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_IS_PENDING_APPROVAL",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_IS_PENDING_APPROVAL"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The order was confirmed and payer action completed but order approval processing from PayPal is pending. No action is needed from Payee or Payer. Please wait until order status changes to 'APPROVED'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DEVICE_DATA_NOT_AVAILABLE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DEVICE_DATA_NOT_AVAILABLE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Device Data is not available for processing this order. The PayPal-Client-Metadata-Id header value sent during `Create Order` api call is either missing or incorrect or there was an error in collecting required data. Please verify if appropriate value for PayPal-Client-Metadata-Id header is being sent during 'Create Order' api call. Please note this error only applies to payment_source.pay_upon_invoice at the moment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CURRENCY_NOT_SUPPORTED_FOR_BANK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CURRENCY_NOT_SUPPORTED_FOR_BANK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payment_source does not support the currency of the Order. For ACH debit, only USD is supported and for SEPA debit, only EUR is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ONLY_ONE_BANK_SOURCE_ALLOWED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ONLY_ONE_BANK_SOURCE_ALLOWED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "More than one payment method within the bank payment object is not supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_IBAN",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_IBAN"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "IBAN provided is not a valid bank account number."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "IBAN_COUNTRY_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "IBAN_COUNTRY_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Country code of issuer bank for the provided IBAN is not supported for SEPA debit payments."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_COUNTRY_NOT_SUPPORTED_FOR_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_COUNTRY_NOT_SUPPORTED_FOR_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payee country code is not supported by the provided payment source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_NUMBER_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_NUMBER_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card number is required when attempting to process payment with card."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_EXPIRY_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_EXPIRY_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card expiry is required when attempting to process payment with card."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INCOMPATIBLE_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INCOMPATIBLE_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of the field is incompatible/redundant with other fields in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "VAULT_INSTRUCTION_DUPLICATED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "VAULT_INSTRUCTION_DUPLICATED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Only one vault instruction is allowed. Please use `vault.store_in_vault` to provide vault instruction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "VAULT_INSTRUCTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "VAULT_INSTRUCTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_TRANSACTION_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PNREF_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PNREF_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `pnref` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_SECURITY_CODE_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_SECURITY_CODE_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The security_code length is invalid for the specified card brand."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API caller or the merchant on whose behalf the API call is initiated is not allowed to vault the given source. Please contact PayPal customer support for assistance."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CRYPTOGRAM_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CRYPTOGRAM_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "EMV_DATA_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "EMV_DATA_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "EMV Data is required if authentication method is EMV."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ALIAS_DECLINED_BY_PROCESSOR",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ALIAS_DECLINED_BY_PROCESSOR"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The provided alias was declined by the processor. Please create a new order with a different alias_key and/or alias_label and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Blik's one_click flow requires one_click.auth_code and one_click.alias_label parameters for the buyer's first transaction. For all subsequent transactions,only the one_click.alias_key parameter is required."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-confirm422-issues"
           }
         }
       },
@@ -9880,1302 +4410,41 @@
         "description": "The authorization of an order request.",
         "properties": {
           "payment_source": {
-            "description": "The source of payment for the order, which can be a token or a card. Use this object only if you have not redirected the user after order creation to approve the payment. In such cases, the user-selected payment method in the PayPal flow is implicitly used.",
-            "$ref": "#/components/schemas/payment_source"
+            "$ref": "#/components/schemas/order-authorize-request-payment-source"
           }
         }
       },
       "order_authorize_response": {
         "type": "object",
-        "title": "Order",
+        "title": "Order Authorize Response",
         "description": "The order authorize response.",
         "allOf": [
           {
             "$ref": "#/components/schemas/activity_timestamps"
           },
           {
-            "properties": {
-              "id": {
-                "type": "string",
-                "description": "The ID of the order.",
-                "readOnly": true
-              },
-              "payment_source": {
-                "$ref": "#/components/schemas/payment_source_response"
-              },
-              "intent": {
-                "$ref": "#/components/schemas/checkout_payment_intent"
-              },
-              "processing_instruction": {
-                "$ref": "#/components/schemas/processing_instruction"
-              },
-              "payer": {
-                "$ref": "#/components/schemas/payer"
-              },
-              "purchase_units": {
-                "type": "array",
-                "description": "An array of purchase units. Each purchase unit establishes a contract between a customer and merchant. Each purchase unit represents either a full or partial order that the customer intends to purchase from the merchant.",
-                "minItems": 1,
-                "maxItems": 10,
-                "items": {
-                  "$ref": "#/components/schemas/purchase_unit",
-                  "description": "A purchase unit. Establishes a contract between a customer and merchant."
-                }
-              },
-              "status": {
-                "$ref": "#/components/schemas/order_status",
-                "readOnly": true
-              },
-              "links": {
-                "type": "array",
-                "description": "An array of request-related HATEOAS links. To complete payer approval, use the `approve` link to redirect the payer. The API caller has 3 hours (default setting, this which can be changed by your account manager to 24/48/72 hours to accommodate your use case) from the time the order is created, to redirect your payer. Once redirected, the API caller has 3 hours for the payer to approve the order and either authorize or capture the order. If you are not using the PayPal JavaScript SDK to initiate PayPal Checkout (in context) ensure that you include `application_context.return_url` is specified or you will get \"We're sorry, Things don't appear to be working at the moment\" after the payer approves the payment.",
-                "readOnly": true,
-                "items": {
-                  "$ref": "#/components/schemas/link_description",
-                  "description": "A request-related [HATEOAS link](/api/rest/responses/#hateoas-links). To complete payer approval, use the `approve` link with the `GET` method."
-                }
-              }
-            }
+            "$ref": "#/components/schemas/order-authorize-response-allof1"
           }
         ]
       },
       "orders.authorize-400": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_COUNTRY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_COUNTRY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Country code is invalid. Please refer to https://developer.paypal.com/api/rest/reference/country-codes/ for a list of supported country codes."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A parameter value is not valid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required field / parameter is missing"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_SYNTAX",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_SYNTAX"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field does not conform to the expected format."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MALFORMED_REQUEST_JSON",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MALFORMED_REQUEST_JSON"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request JSON is not well formed."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-authorize400-issues"
           }
         }
       },
       "orders.authorize-403": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enabled to process payments with the specified type of token. Please contact customer support to request permissions to process transactions with this type of token."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PERMISSION_DENIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You do not have permission to access or perform operations on this resource."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PERMISSION_DENIED_FOR_DONATION_ITEMS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED_FOR_DONATION_ITEMS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller or Payee have not been granted appropriate permissions to send 'items.category' as 'DONATION'. Please speak to your account manager if you want to process these type of items."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-authorize403-issues"
           }
         }
       },
       "orders.authorize-422": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "ACTION_DOES_NOT_MATCH_INTENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ACTION_DOES_NOT_MATCH_INTENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order was created with an intent to 'CAPTURE'. Please use v2/checkout/orders/order_id/capture to complete the transaction or alternately Create an order with an intent of 'AUTHORIZE'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AGREEMENT_ALREADY_CANCELLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AGREEMENT_ALREADY_CANCELLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The requested agreement is already canceled."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_AGREEMENT_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_AGREEMENT_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The requested Billing Agreement token was not found."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_PREVIOUS_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_PREVIOUS_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_CRYPTOGRAM",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_CRYPTOGRAM"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is mandatory for any customer initiated network token transactions."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_BRAND_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_BRAND_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Processing of this card brand is not supported. Please use another card to continue with this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DECLINED_DUE_TO_RELATED_TXN",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DECLINED_DUE_TO_RELATED_TXN"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "One or more transactions in this Order did not succeed. Since this Order is being processed as an All or None Order, if one or more transactions in this Order do not succeed, then all purchase units are marked declined and will not be processed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DOMESTIC_TRANSACTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DOMESTIC_TRANSACTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This transaction requires the payee and payer to be resident in the same country, a domestic transaction is required to create this payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DUPLICATE_INVOICE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DUPLICATE_INVOICE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Duplicate Invoice ID detected. To avoid a potential duplicate transaction your account setting requires that Invoice Id be unique for each transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_NOT_APPROVED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_NOT_APPROVED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payer has not yet approved the Order for payment. Please redirect the payer to the 'rel':'approve' url returned as part of the HATEOAS links within the Create Order call."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You have exceeded the maximum number of payment attempts."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_BLOCKED_TRANSACTION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_BLOCKED_TRANSACTION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The Fraud settings for this seller are such that this payment cannot be executed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_FX_RATE_ID_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_FX_RATE_ID_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "UNSUPPORTED_INTENT_FOR_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "UNSUPPORTED_INTENT_FOR_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`intent=AUTHORIZE` is not supported for the specified payment_source. Only `intent=CAPTURE` is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACCOUNT_LOCKED_OR_CLOSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_LOCKED_OR_CLOSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payer account cannot be used for this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACCOUNT_RESTRICTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_RESTRICTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_RESTRICTED"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_CANNOT_PAY",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_CANNOT_PAY"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payer cannot pay for this transaction. Please contact the payer to find other ways to pay for this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_TRANSACTION_ID_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_TRANSACTION_ID_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `paypal_transaction_id` has expired. PayPal transaction ID expires 4 years after the date of the initial transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PNREF_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PNREF_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `pnref` has expired. PNREF expires 15 months after the date of the initial transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REFERENCED_CARD_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REFERENCED_CARD_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card underlying the token has expired and hence cannot be used to process a payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TOKEN_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TOKEN_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The token is expired and cannot be used for payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TOKEN_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TOKEN_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified token was not found. Verify the token and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_LIMIT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_LIMIT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Total payment amount exceeded transaction limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_RECEIVING_LIMIT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The transaction exceeds the receiver's receiving limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_REFUSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_REFUSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request was refused."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_ALREADY_AUTHORIZED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_ALREADY_AUTHORIZED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order already authorized.If 'intent=AUTHORIZE' only one authorization per order is allowed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AUTH_CAPTURE_NOT_ENABLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AUTH_CAPTURE_NOT_ENABLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Authorization and Capture feature is not enabled for the merchant. Make sure that the recipient of the funds is a verified business account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AMOUNT_CANNOT_BE_SPECIFIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AMOUNT_CANNOT_BE_SPECIFIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "An authorization amount can only be specified if an Order has been saved by calling /v2/checkout/orders/{order_id}/save.  Please save the order and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AUTHORIZATION_AMOUNT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AUTHORIZATION_AMOUNT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Authorization amount specified exceeded allowable limit. Specify a different amount and try the request again. Alternately, contact Customer Support to increase your limits. Local regulations (e.g. in PSD2 countries) prohibit overages above the amount authorized by the payer."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AUTHORIZATION_CURRENCY_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AUTHORIZATION_CURRENCY_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The currency of the authorization should be same as that in which the Order was created and approved by the Payer. Please check the 'currency_code' and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MAX_AUTHORIZATION_COUNT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MAX_AUTHORIZATION_COUNT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Maximum number of authorization allowed for the order is reached. Please contact Customer Support if you need to increase your limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_COMPLETED_OR_VOIDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_COMPLETED_OR_VOIDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order is voided or completed and hence cannot be authorized."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order is expired and hence cannot be authorized. Please contact Customer Support if you need to increase your order validity period."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PICKUP_ADDRESS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PICKUP_ADDRESS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If the 'shipping_option.type' is set as 'PICKUP' then the 'shipping_detail.name.full_name' should start with 'S2S' meaning Ship To Store. Example: 'S2S My Store'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_ADDRESS_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_ADDRESS_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided shipping address is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_TYPE_NOT_SUPPORTED_FOR_INTENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_TYPE_NOT_SUPPORTED_FOR_INTENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided payment type not supported for order intent. Payment authorizations are supported only for order with `intent=AUTHORIZE` and payment captures are supported only for order with `intent=CAPTURE`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_AGREEMENT_ID_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_AGREEMENT_ID_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Billing Agreement ID must exactly match the Billing Agreement ID that was provided during order creation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREFERRED_PAYMENT_SOURCE_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREFERRED_PAYMENT_SOURCE_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payment Source must exactly match the Preferred Payment Source that was provided during order creation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INCOMPATIBLE_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INCOMPATIBLE_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of the field is incompatible/redundant with other fields in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PREVIOUS_TRANSACTION_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PREVIOUS_TRANSACTION_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The authorization or capture referenced by `previous_transaction_reference` is not valid. This could be either because the previous_transaction_reference is not found or doesn't belong to the payee. Please use a valid `previous_transaction_reference`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The capture referenced by `previous_transaction_reference` has a chargeback and hence cannot be used for this order. Please use a `previous_transaction_reference` which does not have a chargeback."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREVIOUS_TRANSACTION_REFERENCE_VOIDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREVIOUS_TRANSACTION_REFERENCE_VOIDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The status of authorization referenced by `previous_transaction_reference` is `VOIDED` and hence cannot be used for this order. Please use a `previous_transaction_reference` whose status is not `VOIDED`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The `payment_source` in the request must match the `payment_source` used for the authorization or capture referenced by `previous_transaction_reference`. Please use `previous_transaction_reference` whose `payment_source` matches with the `payment_source` specified in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_SECURITY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_SECURITY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if `payment_source.card.security_code` is present in the order. `security_code` can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with `security_code` is the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if 3D-Secure authentication results are present in the order. 3D-Secure authentication results can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with 3D-Secure authentication results is the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if more than one purchase_unit is present in the Order. Merchant initiated payments are not supported from orders with more than one purchase_unit. Please retry the request with multiple Order requests (one for each purchase_unit)."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "RETURN_URL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "RETURN_URL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The return url is required when attempting to vault this source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANCEL_URL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANCEL_URL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The cancel url is required when attempting to vault this source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction cannot complete successfully, instruct the buyer to return to PayPal."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "APPLE_PAY_AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "APPLE_PAY_AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_NUMBER_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_NUMBER_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card number is required when attempting to process payment with card."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_EXPIRY_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_EXPIRY_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card expiry is required when attempting to process payment with card."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "VAULT_INSTRUCTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "VAULT_INSTRUCTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_CANNOT_BE_SAVED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_CANNOT_BE_SAVED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The option to save an order is only available if the `intent` is AUTHORIZE and `processing_instruction` uses one of the `ORDER_SAVED` options. For example, `intent`=AUTHORIZE, `processing_instruction`=ORDER_SAVED_EXPLICITLY. Please change the intent and/or processing_instruction` and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SAVE_ORDER_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SAVE_ORDER_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API caller account is setup in a way that does not allow it to be used for saving the order. This functionality is not available for PayPal Commerce Platform for Platforms & Marketplaces."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_TRANSACTION_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PNREF_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PNREF_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `pnref` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_SECURITY_CODE_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_SECURITY_CODE_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The security_code length is invalid for the specified card brand."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-authorize422-issues"
           }
         }
       },
@@ -11192,1342 +4461,21 @@
       "orders.capture-400": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A parameter value is not valid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required field / parameter is missing"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_SYNTAX",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_SYNTAX"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field does not conform to the expected format."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MALFORMED_REQUEST_JSON",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MALFORMED_REQUEST_JSON"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request JSON is not well formed."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-capture400-issues"
           }
         }
       },
       "orders.capture-403": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "CONSENT_NEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CONSENT_NEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "CONSENT_NEEDED"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enabled to process payments with the specified type of token. Please contact customer support to request permissions to process transactions with this type of token."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PERMISSION_DENIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You do not have permission to access or perform operations on this resource."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PERMISSION_DENIED_FOR_DONATION_ITEMS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED_FOR_DONATION_ITEMS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller or Payee have not been granted appropriate permissions to send 'items.category' as 'DONATION'. Please speak to your account manager if you want to process these type of items."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-capture403-issues"
           }
         }
       },
       "orders.capture-422": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "AGREEMENT_ALREADY_CANCELLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AGREEMENT_ALREADY_CANCELLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The requested agreement is already canceled."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_AGREEMENT_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_AGREEMENT_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The requested Billing Agreement token was not found."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DECLINED_DUE_TO_RELATED_TXN",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DECLINED_DUE_TO_RELATED_TXN"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "One or more transactions in this Order did not succeed. Since this Order is being processed as an All or None Order, if one or more transactions in this Order do not succeed, then all purchase units are marked declined and will not be processed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_PREVIOUS_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_PREVIOUS_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_CRYPTOGRAM",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_CRYPTOGRAM"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cryptogram is mandatory for any customer initiated network token transactions."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_BRAND_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_BRAND_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Processing of this card brand is not supported. Please use another card to continue with this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "COMPLIANCE_VIOLATION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "COMPLIANCE_VIOLATION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction is declined due to compliance violation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DOMESTIC_TRANSACTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DOMESTIC_TRANSACTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This transaction requires the payee and payer to be resident in the same country, a domestic transaction is required to create this payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "DUPLICATE_INVOICE_ID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "DUPLICATE_INVOICE_ID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Duplicate Invoice ID detected. To avoid a potential duplicate transaction your account setting requires that Invoice Id be unique for each transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INSTRUMENT_DECLINED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INSTRUMENT_DECLINED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The instrument presented  was either declined by the processor or bank, or it can't be used for this payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_NOT_APPROVED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_NOT_APPROVED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payer has not yet approved the Order for payment. Please redirect the payer to the 'rel':'approve' url returned as part of the HATEOAS links within the Create Order call or provide a valid `payment_source` in the request."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You have exceeded the maximum number of payment attempts."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_BLOCKED_TRANSACTION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_BLOCKED_TRANSACTION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The Fraud settings for this seller are such that this payment cannot be executed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_FX_RATE_ID_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_FX_RATE_ID_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACCOUNT_LOCKED_OR_CLOSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_LOCKED_OR_CLOSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payer account cannot be used for this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACCOUNT_RESTRICTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_RESTRICTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACCOUNT_RESTRICTED"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_CANNOT_PAY",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_CANNOT_PAY"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payer cannot pay for this transaction. Please contact the payer to find other ways to pay for this transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_TRANSACTION_ID_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_TRANSACTION_ID_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `paypal_transaction_id` has expired. PayPal transaction ID expires 4 years after the date of the initial transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PNREF_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PNREF_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `pnref` has expired. PNREF expires 15 months after the date of the initial transaction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REFERENCED_CARD_EXPIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REFERENCED_CARD_EXPIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card underlying the token has expired and hence cannot be used to process a payment."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TOKEN_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TOKEN_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified token was not found. Verify the token and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_LIMIT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_LIMIT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Total payment amount exceeded transaction limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_RECEIVING_LIMIT_EXCEEDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The transaction exceeds the receiver's receiving limit."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_REFUSED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_REFUSED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request was refused."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REDIRECT_PAYER_FOR_ALTERNATE_FUNDING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REDIRECT_PAYER_FOR_ALTERNATE_FUNDING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction failed. Redirect the payer to select another funding source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_ALREADY_CAPTURED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_ALREADY_CAPTURED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Order already captured.If 'intent=CAPTURE' only one capture per order is allowed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "TRANSACTION_BLOCKED_BY_PAYEE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRANSACTION_BLOCKED_BY_PAYEE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction blocked by Payee’s Fraud Protection settings."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "AUTH_CAPTURE_NOT_ENABLED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "AUTH_CAPTURE_NOT_ENABLED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Authorization and Capture feature is not enabled for the merchant. Make sure that the recipient of the funds is a verified business account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_FOR_BANK_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_FOR_BANK_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller account is not setup to be able to process bank payments. Please contact your PayPal account manager."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ENABLED_FOR_CARD_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ENABLED_FOR_CARD_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller account is not setup to be able to process card payments. Please contact PayPal customer support."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_NOT_ENABLED_FOR_BANK_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_NOT_ENABLED_FOR_BANK_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payee account is not setup to be able to process bank payments. Please contact your PayPal account manager."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYEE_NOT_ENABLED_FOR_CARD_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYEE_NOT_ENABLED_FOR_CARD_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payee account is not setup to be able to process card payments. Please contact PayPal customer support."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PICKUP_ADDRESS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PICKUP_ADDRESS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "If the 'shipping_option.type' is set as 'PICKUP' then the 'shipping_detail.name.full_name' should start with 'S2S' meaning Ship To Store. Example: 'S2S My Store'."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SHIPPING_ADDRESS_INVALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SHIPPING_ADDRESS_INVALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Provided shipping address is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payer selected method of payment is not supported when multiple purchase units are specified for an Order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ORDER_COMPLETION_IN_PROGRESS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ORDER_COMPLETION_IN_PROGRESS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The order was created with processing_instruction of ORDER_COMPLETE_ON_PAYMENT_APPROVAL. The customer has approved the payment and PayPal is still in the process of capturing the order on your behalf as instructed. Please try your request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BILLING_AGREEMENT_ID_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BILLING_AGREEMENT_ID_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Billing Agreement ID must exactly match the Billing Agreement ID that was provided during order creation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREFERRED_PAYMENT_SOURCE_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREFERRED_PAYMENT_SOURCE_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Payment Source must exactly match the Preferred Payment Source that was provided during order creation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INCOMPATIBLE_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INCOMPATIBLE_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of the field is incompatible/redundant with other fields in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PREVIOUS_TRANSACTION_REFERENCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PREVIOUS_TRANSACTION_REFERENCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The authorization or capture referenced by `previous_transaction_reference` is not valid. This could be either because the previous_transaction_reference is not found or doesn't belong to the payee. Please use a valid `previous_transaction_reference`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The capture referenced by `previous_transaction_reference` has a chargeback and hence cannot be used for this order. Please use a `previous_transaction_reference` which does not have a chargeback."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PREVIOUS_TRANSACTION_REFERENCE_VOIDED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PREVIOUS_TRANSACTION_REFERENCE_VOIDED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The status of authorization referenced by `previous_transaction_reference` is `VOIDED` and hence cannot be used for this order. Please use a `previous_transaction_reference` whose status is not `VOIDED`."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYMENT_SOURCE_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYMENT_SOURCE_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The `payment_source` in the request must match the `payment_source` used for the authorization or capture referenced by `previous_transaction_reference`. Please use `previous_transaction_reference` whose `payment_source` matches with the `payment_source` specified in the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_SECURITY_CODE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_SECURITY_CODE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if `payment_source.card.security_code` is present in the order. `security_code` can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with `security_code` is the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if 3D-Secure authentication results are present in the order. 3D-Secure authentication results can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with 3D-Secure authentication results is the order."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if more than one purchase_unit is present in the Order. Merchant initiated payments are not supported from orders with more than one purchase_unit. Please retry the request with multiple Order requests (one for each purchase_unit)."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "RETURN_URL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "RETURN_URL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The return url is required when attempting to vault this source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CANCEL_URL_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CANCEL_URL_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The cancel url is required when attempting to vault this source."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "SETUP_ERROR_FOR_BANK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "SETUP_ERROR_FOR_BANK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The API Caller account setup, for bank payments, is incomplete or incorrect. Please contact your PayPal account manager."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "BANK_NOT_SUPPORTED_FOR_VERIFICATION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "BANK_NOT_SUPPORTED_FOR_VERIFICATION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Verification for this bank account is not supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYER_ACTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYER_ACTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Transaction cannot complete successfully, instruct the buyer to return to PayPal."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "APPLE_PAY_AMOUNT_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "APPLE_PAY_AMOUNT_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CURRENCY_NOT_SUPPORTED_FOR_BANK",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CURRENCY_NOT_SUPPORTED_FOR_BANK"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payment_source does not support the currency of the Order. For ACH debit, only USD is supported and for SEPA debit, only EUR is supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ONLY_ONE_BANK_SOURCE_ALLOWED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ONLY_ONE_BANK_SOURCE_ALLOWED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "More than one payment method within the bank payment object is not supported."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_IBAN",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_IBAN"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "IBAN provided is not a valid bank account number."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "IBAN_COUNTRY_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "IBAN_COUNTRY_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Country code of issuer bank for the provided IBAN is not supported for SEPA debit payments."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_NUMBER_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_NUMBER_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card number is required when attempting to process payment with card."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CARD_EXPIRY_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CARD_EXPIRY_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The card expiry is required when attempting to process payment with card."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "VAULT_INSTRUCTION_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "VAULT_INSTRUCTION_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PAYPAL_TRANSACTION_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PNREF_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PNREF_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified `pnref` was not found. Verify the value and try the request again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_SECURITY_CODE_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_SECURITY_CODE_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The security_code length is invalid for the specified card brand."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PLATFORM_FEE_PAYEE_CANNOT_BE_SAME_AS_PAYER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PLATFORM_FEE_PAYEE_CANNOT_BE_SAME_AS_PAYER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The payer cannot pay themselves. The recipient account of the platform fees must be different from the payer account."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "IDENTIFIER_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "IDENTIFIER_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified identifier was not found. Please verify the correct identifier was used and try the request again."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-capture422-issues"
           }
         }
       },
@@ -13881,15 +5829,13 @@
             "maxLength": 64
           },
           "tracking_number_type": {
-            "description": "The type of tracking number.",
-            "$ref": "#/components/schemas/shipment_tracking_number_type"
+            "$ref": "#/components/schemas/shipment-tracker-tracking-number-type"
           },
           "status": {
             "$ref": "#/components/schemas/shipment_tracking_status"
           },
           "shipment_date": {
-            "description": "The date when the shipment occurred, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "$ref": "#/components/schemas/date_no_time"
+            "$ref": "#/components/schemas/shipment-tracker-shipment-date"
           },
           "carrier": {
             "$ref": "#/components/schemas/shipment_carrier"
@@ -13925,32 +5871,13 @@
             "readOnly": true
           },
           "last_updated_time": {
-            "description": "The date and time when the tracking information was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
-            "$ref": "#/components/schemas/date_time"
+            "$ref": "#/components/schemas/shipment-tracker-last-updated-time"
           },
           "shipment_direction": {
-            "type": "string",
-            "description": "To denote whether the shipment is sent forward to the receiver or returned back.",
-            "minLength": 1,
-            "maxLength": 50,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "FORWARD",
-              "RETURN"
-            ]
+            "$ref": "#/components/schemas/shipment-tracker-shipment-direction"
           },
           "shipment_uploader": {
-            "readOnly": true,
-            "type": "string",
-            "description": "To denote which party uploaded the shipment tracking info.",
-            "minLength": 1,
-            "maxLength": 50,
-            "pattern": "^[0-9A-Z_]+$",
-            "enum": [
-              "MERCHANT",
-              "CONSUMER",
-              "PARTNER"
-            ]
+            "$ref": "#/components/schemas/shipment-tracker-shipment-uploader"
           }
         },
         "required": [
@@ -13967,484 +5894,14268 @@
             "$ref": "#/components/schemas/shipment_tracker"
           },
           {
-            "properties": {
-              "capture_id": {
-                "type": "string",
-                "description": "The PayPal capture ID.",
-                "minLength": 1,
-                "maxLength": 50,
-                "pattern": "^[a-zA-Z0-9]*$"
-              },
-              "notify_payer": {
-                "type": "boolean",
-                "description": "If true, sends an email notification to the payer of the PayPal transaction. The email contains the tracking information that was uploaded through the API.",
-                "default": false
-              },
-              "items": {
-                "type": "array",
-                "description": "An array of details of items in the shipment.",
-                "items": {
-                  "description": "Items in a shipment.",
-                  "$ref": "#/components/schemas/tracker_item"
-                }
-              }
-            },
-            "required": [
-              "capture_id"
-            ]
+            "$ref": "#/components/schemas/order-tracker-request-allof1"
           }
         ]
       },
       "orders.track.create-400": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required field / parameter is missing."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A parameter value is not valid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_SYNTAX",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_SYNTAX"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field does not conform to the expected format."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-track-create400-issues"
           }
         }
       },
       "orders.track.create-403": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "PERMISSION_DENIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You do not have permission to access or perform operations on this resource."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-track-create403-issues"
           }
         }
       },
       "orders.track.create-422": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "CAPTURE_STATUS_NOT_VALID",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CAPTURE_STATUS_NOT_VALID"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Invalid capture status. Tracker information can only be added to captures in `COMPLETED` state."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_SKU_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_SKU_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Item sku must match one of the items sku that was provided during order creation."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "CAPTURE_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "CAPTURE_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified capture ID does not exist. Check the capture ID and try again."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MSP_NOT_SUPPORTED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MSP_NOT_SUPPORTED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Multiple purchase units are not supported for this operation."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-track-create422-issues"
           }
         }
       },
       "orders.trackers.patch-400": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "FIELD_NOT_PATCHABLE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "FIELD_NOT_PATCHABLE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Field cannot be patched."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PARAMETER_VALUE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PARAMETER_VALUE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is invalid."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MISSING_REQUIRED_PARAMETER",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MISSING_REQUIRED_PARAMETER"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "A required field or parameter is missing."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_STRING_LENGTH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_STRING_LENGTH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The value of a field is either too short or too long."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "INVALID_PATCH_OPERATION",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_PATCH_OPERATION"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The operation cannot be honored. Cannot add a property that's already present, use replace. Cannot remove a property thats not present, use add. Cannot replace a property thats not present, use add."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "MALFORMED_REQUEST_JSON",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "MALFORMED_REQUEST_JSON"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "The request JSON is not well formed."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-trackers-patch400-issues"
           }
         }
       },
       "orders.trackers.patch-403": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "PERMISSION_DENIED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PERMISSION_DENIED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "You do not have permission to access or perform operations on this resource."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-trackers-patch403-issues"
           }
         }
       },
       "orders.trackers.patch-404": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "TRACKER_ID_NOT_FOUND",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "TRACKER_ID_NOT_FOUND"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specified tracker ID does not exist. Check the tracker ID and try again."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-trackers-patch404-issues"
           }
         }
       },
       "orders.trackers.patch-422": {
         "properties": {
           "issues": {
-            "type": "array",
-            "items": {
-              "anyOf": [
-                {
-                  "title": "INVALID_JSON_POINTER_FORMAT",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "INVALID_JSON_POINTER_FORMAT"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Path should be a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) that references a location within the request where the operation is performed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "NOT_PATCHABLE",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "NOT_PATCHABLE"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Cannot be patched."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PATCH_VALUE_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PATCH_VALUE_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specify a `value` for the field being patched."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "PATCH_PATH_REQUIRED",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "PATCH_PATH_REQUIRED"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Specify a `value` for the field in which the operation needs to be performed."
-                      ]
-                    }
-                  }
-                },
-                {
-                  "title": "ITEM_SKU_MISMATCH",
-                  "properties": {
-                    "issue": {
-                      "type": "string",
-                      "enum": [
-                        "ITEM_SKU_MISMATCH"
-                      ]
-                    },
-                    "description": {
-                      "type": "string",
-                      "enum": [
-                        "Item sku must match one of the items sku that was provided during order creation."
-                      ]
-                    }
-                  }
-                }
-              ]
-            }
+            "$ref": "#/components/schemas/orders-trackers-patch422-issues"
           }
         }
+      },
+      "orders-create-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/bad_request_error"
+          }
+        ]
+      },
+      "orders-create-response401-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/unauthorized_request_error"
+          }
+        ]
+      },
+      "orders-create-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/unprocessable_entity_error"
+          }
+        ]
+      },
+      "orders-get-response401-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/unauthorized_request_error"
+          }
+        ]
+      },
+      "orders-get-response404-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/not_found_error"
+          }
+        ]
+      },
+      "orders-patch-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/orders.patch-400"
+          }
+        ]
+      },
+      "orders-patch-response401-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/unauthorized_request_error"
+          }
+        ]
+      },
+      "orders-patch-response404-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/not_found_error"
+          }
+        ]
+      },
+      "orders-patch-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/orders.patch-422"
+          }
+        ]
+      },
+      "orders-confirm-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/orders.confirm-400"
+          }
+        ]
+      },
+      "orders-confirm-response403-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/forbidden_error"
+          }
+        ]
+      },
+      "orders-confirm-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/orders.confirm-422"
+          }
+        ]
+      },
+      "orders-authorize-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/orders.authorize-400"
+          }
+        ]
+      },
+      "orders-authorize-response401-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/unauthorized_request_error"
+          }
+        ]
+      },
+      "orders-authorize-response403-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/orders.authorize-403"
+          }
+        ]
+      },
+      "orders-authorize-response404-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/not_found_error"
+          }
+        ]
+      },
+      "orders-authorize-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/orders.authorize-422"
+          }
+        ]
+      },
+      "orders-capture-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/orders.capture-400"
+          }
+        ]
+      },
+      "orders-capture-response401-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_401"
+          },
+          {
+            "$ref": "#/components/schemas/unauthorized_request_error"
+          }
+        ]
+      },
+      "orders-capture-response403-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/orders.capture-403"
+          }
+        ]
+      },
+      "orders-capture-response404-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/not_found_error"
+          }
+        ]
+      },
+      "orders-capture-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/orders.capture-422"
+          }
+        ]
+      },
+      "orders-track-create-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/orders.track.create-400"
+          }
+        ]
+      },
+      "orders-track-create-response403-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/orders.track.create-403"
+          }
+        ]
+      },
+      "orders-track-create-response404-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/not_found_error"
+          }
+        ]
+      },
+      "orders-track-create-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/orders.track.create-422"
+          }
+        ]
+      },
+      "orders-trackers-patch-response400-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_400"
+          },
+          {
+            "$ref": "#/components/schemas/orders.trackers.patch-400"
+          }
+        ]
+      },
+      "orders-trackers-patch-response403-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_403"
+          },
+          {
+            "$ref": "#/components/schemas/orders.trackers.patch-403"
+          }
+        ]
+      },
+      "orders-trackers-patch-response404-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_404"
+          },
+          {
+            "$ref": "#/components/schemas/orders.trackers.patch-404"
+          }
+        ]
+      },
+      "orders-trackers-patch-response422-json": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/error_422"
+          },
+          {
+            "$ref": "#/components/schemas/orders.trackers.patch-422"
+          }
+        ]
+      },
+      "bad-request-error-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/bad-request-error-issues-items"
+        }
+      },
+      "bad-request-error-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-array-max-items"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-array-min-items"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-country-code"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-syntax"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value"
+          },
+          {
+            "$ref": "#/components/schemas/missing-required-parameter"
+          },
+          {
+            "$ref": "#/components/schemas/not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-request-id-required"
+          },
+          {
+            "$ref": "#/components/schemas/malformed-request-json"
+          }
+        ]
+      },
+      "invalid-array-max-items": {
+        "title": "INVALID_ARRAY_MAX_ITEMS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-array-max-items-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-array-max-items-description"
+          }
+        }
+      },
+      "invalid-array-min-items": {
+        "title": "INVALID_ARRAY_MIN_ITEMS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-array-min-items-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-array-min-items-description"
+          }
+        }
+      },
+      "invalid-country-code": {
+        "title": "INVALID_COUNTRY_CODE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-country-code-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-country-code-description"
+          }
+        }
+      },
+      "invalid-parameter-syntax": {
+        "title": "INVALID_PARAMETER_SYNTAX",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax-description"
+          }
+        }
+      },
+      "invalid-string-length": {
+        "title": "INVALID_STRING_LENGTH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length-description"
+          }
+        }
+      },
+      "invalid-parameter-value": {
+        "title": "INVALID_PARAMETER_VALUE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value-description"
+          }
+        }
+      },
+      "missing-required-parameter": {
+        "title": "MISSING_REQUIRED_PARAMETER",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter-description"
+          }
+        }
+      },
+      "not-supported": {
+        "title": "NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-supported-description"
+          }
+        }
+      },
+      "paypal-request-id-required": {
+        "title": "PAYPAL_REQUEST_ID_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-request-id-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-request-id-required-description"
+          }
+        }
+      },
+      "malformed-request-json": {
+        "title": "MALFORMED_REQUEST_JSON",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/malformed-request-json-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/malformed-request-json-description"
+          }
+        }
+      },
+      "unauthorized-request-error-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/unauthorized-request-error-issues-items"
+        }
+      },
+      "unauthorized-request-error-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-account-status"
+          }
+        ]
+      },
+      "invalid-account-status": {
+        "title": "INVALID_ACCOUNT_STATUS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-account-status-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-account-status-description"
+          }
+        }
+      },
+      "forbidden-error-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/forbidden-error-issues-items"
+        }
+      },
+      "forbidden-error-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/permission-denied"
+          },
+          {
+            "$ref": "#/components/schemas/not_enabled_for_card_processing"
+          },
+          {
+            "$ref": "#/components/schemas/payee-account-not-verified"
+          }
+        ]
+      },
+      "permission-denied": {
+        "title": "PERMISSION_DENIED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied-description"
+          }
+        }
+      },
+      "payee-account-not-verified": {
+        "title": "PAYEE_ACCOUNT_NOT_VERIFIED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-account-not-verified-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-account-not-verified-description"
+          }
+        }
+      },
+      "not-found-error-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/not-found-error-issues-items"
+        }
+      },
+      "not-found-error-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-resource-id"
+          }
+        ]
+      },
+      "invalid-resource-id": {
+        "title": "INVALID_RESOURCE_ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-resource-id-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-resource-id-description"
+          }
+        }
+      },
+      "unprocessable-entity-error-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/unprocessable-entity-error-issues-items"
+        }
+      },
+      "unprocessable-entity-error-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/amount-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/cannot-be-negative"
+          },
+          {
+            "$ref": "#/components/schemas/cannot-be-zero-or-negative"
+          },
+          {
+            "$ref": "#/components/schemas/card-expired"
+          },
+          {
+            "$ref": "#/components/schemas/missing-previous-reference"
+          },
+          {
+            "$ref": "#/components/schemas/missing-cryptogram"
+          },
+          {
+            "$ref": "#/components/schemas/city-required"
+          },
+          {
+            "$ref": "#/components/schemas/decimal-precision"
+          },
+          {
+            "$ref": "#/components/schemas/donation-items-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/duplicate-reference-id"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-currency-code"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-payer-id"
+          },
+          {
+            "$ref": "#/components/schemas/item-total-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/item-total-required"
+          },
+          {
+            "$ref": "#/components/schemas/max-value-exceeded"
+          },
+          {
+            "$ref": "#/components/schemas/missing-pickup-address"
+          },
+          {
+            "$ref": "#/components/schemas/multi-currency-order"
+          },
+          {
+            "$ref": "#/components/schemas/multiple-item-categories"
+          },
+          {
+            "$ref": "#/components/schemas/multiple-shipping-address-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/multiple-shipping-type-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/payee-account-invalid"
+          },
+          {
+            "$ref": "#/components/schemas/payee-account-locked-or-closed"
+          },
+          {
+            "$ref": "#/components/schemas/payee-account-restricted"
+          },
+          {
+            "$ref": "#/components/schemas/payee-pricing-tier-id-not-enabled"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-payee-pricing-tier-id"
+          },
+          {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired"
+          },
+          {
+            "$ref": "#/components/schemas/payee-fx-rate-id-currency-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-fx-rate-id"
+          },
+          {
+            "$ref": "#/components/schemas/platform-fees-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-platform-fees-account"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-platform-fees-amount"
+          },
+          {
+            "$ref": "#/components/schemas/postal-code-required"
+          },
+          {
+            "$ref": "#/components/schemas/reference-id-required"
+          },
+          {
+            "$ref": "#/components/schemas/shipping_option_not_supported"
+          },
+          {
+            "$ref": "#/components/schemas/tax-total-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/tax-total-required"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-intent"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-payment-instruction"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-type-not-supported-for-client"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-shipping-type"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-option-not-selected"
+          },
+          {
+            "$ref": "#/components/schemas/shipping_option_not_supported"
+          },
+          {
+            "$ref": "#/components/schemas/multiple-shipping-option-selected"
+          },
+          {
+            "$ref": "#/components/schemas/preferred-shipping-option-amount-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/agreement-already-cancelled"
+          },
+          {
+            "$ref": "#/components/schemas/billing-agreement-not-found"
+          },
+          {
+            "$ref": "#/components/schemas/compliance-violation"
+          },
+          {
+            "$ref": "#/components/schemas/domestic-transaction-required"
+          },
+          {
+            "$ref": "#/components/schemas/duplicate-invoice-id"
+          },
+          {
+            "$ref": "#/components/schemas/instrument-declined"
+          },
+          {
+            "$ref": "#/components/schemas/max-number-of-payment-attempts-exceeded"
+          },
+          {
+            "$ref": "#/components/schemas/not_enabled_for_card_processing"
+          },
+          {
+            "$ref": "#/components/schemas/payee-blocked-transaction"
+          },
+          {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed"
+          },
+          {
+            "$ref": "#/components/schemas/payer-account-restricted"
+          },
+          {
+            "$ref": "#/components/schemas/payer-cannot-pay"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-blocked-by-payee"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-limit-exceeded"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-refused"
+          },
+          {
+            "$ref": "#/components/schemas/auth-capture-not-enabled"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-processing-instruction"
+          },
+          {
+            "$ref": "#/components/schemas/order-complete-on-payment-approval"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-expiry-date"
+          },
+          {
+            "$ref": "#/components/schemas/incompatible-parameter-value"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference"
+          },
+          {
+            "$ref": "#/components/schemas/previous-transaction-reference-has-chargeback"
+          },
+          {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-authentication-results"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-multiple-purchase-units"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-info-cannot-be-verified"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-declined-by-processor"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-cannot-be-used"
+          },
+          {
+            "$ref": "#/components/schemas/not-enabled-for-apple-pay"
+          },
+          {
+            "$ref": "#/components/schemas/not-enabled-for-google-pay"
+          },
+          {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/billing-address-invalid"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-address-invalid"
+          },
+          {
+            "$ref": "#/components/schemas/vault-instruction-duplicated"
+          },
+          {
+            "$ref": "#/components/schemas/vault-instruction-required"
+          },
+          {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/cryptogram-required"
+          },
+          {
+            "$ref": "#/components/schemas/emv-data-required"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-paypal-transaction-id-processing"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found"
+          },
+          {
+            "$ref": "#/components/schemas/pnref-not-found"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-security-code-length"
+          },
+          {
+            "$ref": "#/components/schemas/not-enabled-to-vault-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/required-parameter-for-customer-initiated-payment"
+          },
+          {
+            "$ref": "#/components/schemas/token-expired"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-google-pay-token"
+          },
+          {
+            "$ref": "#/components/schemas/google-pay-gateway-merchant-id-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/cryptogram-required1"
+          },
+          {
+            "$ref": "#/components/schemas/one-of-parameters-required"
+          },
+          {
+            "$ref": "#/components/schemas/alias-declined-by-processor"
+          },
+          {
+            "$ref": "#/components/schemas/blik-one-click-missing-required-parameter"
+          }
+        ]
+      },
+      "amount-mismatch": {
+        "title": "AMOUNT_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/amount-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/amount-mismatch-description"
+          }
+        }
+      },
+      "cannot-be-negative": {
+        "title": "CANNOT_BE_NEGATIVE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cannot-be-negative-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cannot-be-negative-description"
+          }
+        }
+      },
+      "cannot-be-zero-or-negative": {
+        "title": "CANNOT_BE_ZERO_OR_NEGATIVE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cannot-be-zero-or-negative-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cannot-be-zero-or-negative-description"
+          }
+        }
+      },
+      "card-expired": {
+        "title": "CARD_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-expired-description"
+          }
+        }
+      },
+      "missing-previous-reference": {
+        "title": "MISSING_PREVIOUS_REFERENCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-previous-reference-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-previous-reference-description"
+          }
+        }
+      },
+      "missing-cryptogram": {
+        "title": "MISSING_CRYPTOGRAM",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-cryptogram-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-cryptogram-description"
+          }
+        }
+      },
+      "city-required": {
+        "title": "CITY_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/city-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/city-required-description"
+          }
+        }
+      },
+      "decimal-precision": {
+        "title": "DECIMAL_PRECISION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/decimal-precision-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/decimal-precision-description"
+          }
+        }
+      },
+      "donation-items-not-supported": {
+        "title": "DONATION_ITEMS_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/donation-items-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/donation-items-not-supported-description"
+          }
+        }
+      },
+      "duplicate-reference-id": {
+        "title": "DUPLICATE_REFERENCE_ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/duplicate-reference-id-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/duplicate-reference-id-description"
+          }
+        }
+      },
+      "invalid-currency-code": {
+        "title": "INVALID_CURRENCY_CODE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-currency-code-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-currency-code-description"
+          }
+        }
+      },
+      "invalid-payer-id": {
+        "title": "INVALID_PAYER_ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-payer-id-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-payer-id-description"
+          }
+        }
+      },
+      "item-total-mismatch": {
+        "title": "ITEM_TOTAL_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-total-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/item-total-mismatch-description"
+          }
+        }
+      },
+      "item-total-required": {
+        "title": "ITEM_TOTAL_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-total-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/item-total-required-description"
+          }
+        }
+      },
+      "max-value-exceeded": {
+        "title": "MAX_VALUE_EXCEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/max-value-exceeded-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/max-value-exceeded-description"
+          }
+        }
+      },
+      "missing-pickup-address": {
+        "title": "MISSING_PICKUP_ADDRESS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-pickup-address-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-pickup-address-description"
+          }
+        }
+      },
+      "multi-currency-order": {
+        "title": "MULTI_CURRENCY_ORDER",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multi-currency-order-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multi-currency-order-description"
+          }
+        }
+      },
+      "multiple-item-categories": {
+        "title": "MULTIPLE_ITEM_CATEGORIES",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multiple-item-categories-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multiple-item-categories-description"
+          }
+        }
+      },
+      "multiple-shipping-address-not-supported": {
+        "title": "MULTIPLE_SHIPPING_ADDRESS_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multiple-shipping-address-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multiple-shipping-addresses-not-supported"
+          }
+        }
+      },
+      "multiple-shipping-type-not-supported": {
+        "title": "MULTIPLE_SHIPPING_TYPE_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multiple-shipping-type-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multiple-shipping-type-not-supported-description"
+          }
+        }
+      },
+      "payee-account-invalid": {
+        "title": "PAYEE_ACCOUNT_INVALID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-account-invalid-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-account-invalid-description"
+          }
+        }
+      },
+      "payee-account-locked-or-closed": {
+        "title": "PAYEE_ACCOUNT_LOCKED_OR_CLOSED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-account-locked-or-closed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-account-locked-or-closed-description"
+          }
+        }
+      },
+      "payee-account-restricted": {
+        "title": "PAYEE_ACCOUNT_RESTRICTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-account-restricted-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-account-restricted-description"
+          }
+        }
+      },
+      "payee-pricing-tier-id-not-enabled": {
+        "title": "PAYEE_PRICING_TIER_ID_NOT_ENABLED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-pricing-tier-id-not-enabled-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-pricing-tier-id-not-enabled-description"
+          }
+        }
+      },
+      "invalid-payee-pricing-tier-id": {
+        "title": "INVALID_PAYEE_PRICING_TIER_ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-payee-pricing-tier-id-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-payee-pricing-tier-id-description"
+          }
+        }
+      },
+      "payee-fx-rate-id-expired": {
+        "title": "PAYEE_FX_RATE_ID_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired-description"
+          }
+        }
+      },
+      "payee-fx-rate-id-currency-mismatch": {
+        "title": "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-currency-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-currency-mismatch-description"
+          }
+        }
+      },
+      "invalid-fx-rate-id": {
+        "title": "INVALID_FX_RATE_ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-fx-rate-id-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-fx-rate-id-description"
+          }
+        }
+      },
+      "platform-fees-not-supported": {
+        "title": "PLATFORM_FEES_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/platform-fees-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/platform-fees-not-supported-description"
+          }
+        }
+      },
+      "invalid-platform-fees-account": {
+        "title": "INVALID_PLATFORM_FEES_ACCOUNT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-platform-fees-account-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-platform-fees-account-description"
+          }
+        }
+      },
+      "invalid-platform-fees-amount": {
+        "title": "INVALID_PLATFORM_FEES_AMOUNT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-platform-fees-amount-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-platform-fees-amount-description"
+          }
+        }
+      },
+      "postal-code-required": {
+        "title": "POSTAL_CODE_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/postal-code-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/postal-code-required-description"
+          }
+        }
+      },
+      "reference-id-required": {
+        "title": "REFERENCE_ID_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/reference-id-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/reference-id-required-description"
+          }
+        }
+      },
+      "tax-total-mismatch": {
+        "title": "TAX_TOTAL_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/tax-total-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/tax-total-mismatch-description"
+          }
+        }
+      },
+      "tax-total-required": {
+        "title": "TAX_TOTAL_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/tax-total-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/tax-total-required-description"
+          }
+        }
+      },
+      "unsupported-intent": {
+        "title": "UNSUPPORTED_INTENT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-intent-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-intent-description"
+          }
+        }
+      },
+      "unsupported-payment-instruction": {
+        "title": "UNSUPPORTED_PAYMENT_INSTRUCTION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-payment-instruction-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-payment-instruction-description"
+          }
+        }
+      },
+      "shipping-type-not-supported-for-client": {
+        "title": "SHIPPING_TYPE_NOT_SUPPORTED_FOR_CLIENT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-type-not-supported-for-client-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-type-not-supported-for-client-description"
+          }
+        }
+      },
+      "unsupported-shipping-type": {
+        "title": "UNSUPPORTED_SHIPPING_TYPE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-shipping-type-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-shipping-type-description"
+          }
+        }
+      },
+      "shipping-option-not-selected": {
+        "title": "SHIPPING_OPTION_NOT_SELECTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-option-not-selected-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-option-not-selected-description"
+          }
+        }
+      },
+      "multiple-shipping-option-selected": {
+        "title": "MULTIPLE_SHIPPING_OPTION_SELECTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multiple-shipping-option-selected-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multiple-shipping-option-selected-description"
+          }
+        }
+      },
+      "preferred-shipping-option-amount-mismatch": {
+        "title": "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/preferred-shipping-option-amount-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/preferred-shipping-amount-match-amount-breakdown"
+          }
+        }
+      },
+      "agreement-already-cancelled": {
+        "title": "AGREEMENT_ALREADY_CANCELLED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/agreement-already-cancelled-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/agreement-already-cancelled-description"
+          }
+        }
+      },
+      "billing-agreement-not-found": {
+        "title": "BILLING_AGREEMENT_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-agreement-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-agreement-not-found-description"
+          }
+        }
+      },
+      "compliance-violation": {
+        "title": "COMPLIANCE_VIOLATION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/compliance-violation-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/compliance-violation-description"
+          }
+        }
+      },
+      "domestic-transaction-required": {
+        "title": "DOMESTIC_TRANSACTION_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/domestic-transaction-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/domestic-transaction-required-description"
+          }
+        }
+      },
+      "duplicate-invoice-id": {
+        "title": "DUPLICATE_INVOICE_ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/duplicate-invoice-id-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/duplicate-invoice-id-description"
+          }
+        }
+      },
+      "instrument-declined": {
+        "title": "INSTRUMENT_DECLINED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/instrument-declined-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/instrument-declined-description"
+          }
+        }
+      },
+      "max-number-of-payment-attempts-exceeded": {
+        "title": "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/max-number-of-payment-attempts-exceeded-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/exceeded-max-payment-attempts"
+          }
+        }
+      },
+      "payee-blocked-transaction": {
+        "title": "PAYEE_BLOCKED_TRANSACTION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-blocked-transaction-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-blocked-transaction-description"
+          }
+        }
+      },
+      "payer-account-locked-or-closed": {
+        "title": "PAYER_ACCOUNT_LOCKED_OR_CLOSED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed-description"
+          }
+        }
+      },
+      "payer-account-restricted": {
+        "title": "PAYER_ACCOUNT_RESTRICTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-account-restricted-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-account-restricted-description"
+          }
+        }
+      },
+      "payer-cannot-pay": {
+        "title": "PAYER_CANNOT_PAY",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-cannot-pay-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-cannot-pay-description"
+          }
+        }
+      },
+      "transaction-blocked-by-payee": {
+        "title": "TRANSACTION_BLOCKED_BY_PAYEE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-blocked-by-payee-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-blocked-by-payee-description"
+          }
+        }
+      },
+      "transaction-limit-exceeded": {
+        "title": "TRANSACTION_LIMIT_EXCEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-limit-exceeded-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-limit-exceeded-description"
+          }
+        }
+      },
+      "transaction-receiving-limit-exceeded": {
+        "title": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded-description"
+          }
+        }
+      },
+      "transaction-refused": {
+        "title": "TRANSACTION_REFUSED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-refused-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-refused-description"
+          }
+        }
+      },
+      "auth-capture-not-enabled": {
+        "title": "AUTH_CAPTURE_NOT_ENABLED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/auth-capture-not-enabled-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/auth-capture-not-enabled-description"
+          }
+        }
+      },
+      "unsupported-processing-instruction": {
+        "title": "UNSUPPORTED_PROCESSING_INSTRUCTION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-processing-instruction-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-processing-instruction-description"
+          }
+        }
+      },
+      "order-complete-on-payment-approval": {
+        "title": "ORDER_COMPLETE_ON_PAYMENT_APPROVAL",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-complete-on-payment-approval-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-complete-on-payment-approval-description"
+          }
+        }
+      },
+      "invalid-expiry-date": {
+        "title": "INVALID_EXPIRY_DATE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-expiry-date-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-expiry-date-description"
+          }
+        }
+      },
+      "incompatible-parameter-value": {
+        "title": "INCOMPATIBLE_PARAMETER_VALUE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/incompatible-parameter-value-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/incompatible-parameter-value-description"
+          }
+        }
+      },
+      "invalid-previous-transaction-reference": {
+        "title": "INVALID_PREVIOUS_TRANSACTION_REFERENCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference-description"
+          }
+        }
+      },
+      "previous-transaction-reference-has-chargeback": {
+        "title": "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/previous-transaction-reference-chargeback"
+          },
+          "description": {
+            "$ref": "#/components/schemas/capture-with-chargeback-not-usable"
+          }
+        }
+      },
+      "previous-transaction-reference-voided": {
+        "title": "PREVIOUS_TRANSACTION_REFERENCE_VOIDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided-description"
+          }
+        }
+      },
+      "payment-source-mismatch": {
+        "title": "PAYMENT_SOURCE_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-mismatch-description"
+          }
+        }
+      },
+      "merchant-initiated-with-security-code": {
+        "title": "MERCHANT_INITIATED_WITH_SECURITY_CODE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code-description"
+          }
+        }
+      },
+      "merchant-initiated-with-authentication-results": {
+        "title": "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-authentication-results"
+          },
+          "description": {
+            "$ref": "#/components/schemas/error-merchant-initiated-with-auth-results-and-3ds"
+          }
+        }
+      },
+      "merchant-initiated-with-multiple-purchase-units": {
+        "title": "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-multiple-purchase-units"
+          },
+          "description": {
+            "$ref": "#/components/schemas/error-merchant-initiated-multiple-units"
+          }
+        }
+      },
+      "payment-source-info-cannot-be-verified": {
+        "title": "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-info-cannot-be-verified-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-info-cannot-be-verified-description"
+          }
+        }
+      },
+      "payment-source-declined-by-processor": {
+        "title": "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-declined-by-processor-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-declined-by-processor-description"
+          }
+        }
+      },
+      "payment-source-cannot-be-used": {
+        "title": "PAYMENT_SOURCE_CANNOT_BE_USED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-cannot-be-used-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-cannot-be-used-description"
+          }
+        }
+      },
+      "not-enabled-for-apple-pay": {
+        "title": "NOT_ENABLED_FOR_APPLE_PAY",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-enabled-for-apple-pay-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-enabled-for-apple-pay-description"
+          }
+        }
+      },
+      "not-enabled-for-google-pay": {
+        "title": "NOT_ENABLED_FOR_GOOGLE_PAY",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-enabled-for-google-pay-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-enabled-for-google-pay-description"
+          }
+        }
+      },
+      "apple-pay-amount-mismatch": {
+        "title": "APPLE_PAY_AMOUNT_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch-description"
+          }
+        }
+      },
+      "billing-address-invalid": {
+        "title": "BILLING_ADDRESS_INVALID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-address-invalid-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-address-invalid-description"
+          }
+        }
+      },
+      "shipping-address-invalid": {
+        "title": "SHIPPING_ADDRESS_INVALID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-address-invalid-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-address-invalid-description"
+          }
+        }
+      },
+      "vault-instruction-duplicated": {
+        "title": "VAULT_INSTRUCTION_DUPLICATED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/vault-instruction-duplicated-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/vault-instruction-duplicated-description"
+          }
+        }
+      },
+      "vault-instruction-required": {
+        "title": "VAULT_INSTRUCTION_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/vault-instruction-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/vault-instruction-required-description"
+          }
+        }
+      },
+      "mismatched-vault-id-to-payment-source": {
+        "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source-description"
+          }
+        }
+      },
+      "cryptogram-required": {
+        "title": "CRYPTOGRAM_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cryptogram-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cryptogram-required-description"
+          }
+        }
+      },
+      "emv-data-required": {
+        "title": "EMV_DATA_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/emv-data-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/emv-data-required-description"
+          }
+        }
+      },
+      "not-eligible-for-pnref-processing": {
+        "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing-description"
+          }
+        }
+      },
+      "not-eligible-for-paypal-transaction-id-processing": {
+        "title": "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-paypal-id-processing"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-processing-permission-needed"
+          }
+        }
+      },
+      "paypal-transaction-id-not-found": {
+        "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found-description"
+          }
+        }
+      },
+      "pnref-not-found": {
+        "title": "PNREF_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/pnref-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/pnref-not-found-description"
+          }
+        }
+      },
+      "invalid-security-code-length": {
+        "title": "INVALID_SECURITY_CODE_LENGTH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-security-code-length-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-security-code-length-description"
+          }
+        }
+      },
+      "not-enabled-to-vault-payment-source": {
+        "title": "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-enabled-to-vault-payment-source-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-enabled-to-vault-payment-source-description"
+          }
+        }
+      },
+      "required-parameter-for-customer-initiated-payment": {
+        "title": "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/required-param-for-customer-initiated-payment"
+          },
+          "description": {
+            "$ref": "#/components/schemas/req-param-cust-present-initiator-merch"
+          }
+        }
+      },
+      "token-expired": {
+        "title": "TOKEN_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/token-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/token-expired-description"
+          }
+        }
+      },
+      "invalid-google-pay-token": {
+        "title": "INVALID_GOOGLE_PAY_TOKEN",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-google-pay-token-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-google-pay-token-description"
+          }
+        }
+      },
+      "google-pay-gateway-merchant-id-mismatch": {
+        "title": "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/google-pay-gateway-merchant-id-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-google-pay-merchant-id"
+          }
+        }
+      },
+      "cryptogram-required1": {
+        "title": "Cryptogram Required",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cryptogram-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cryptogram-required1-description"
+          }
+        }
+      },
+      "one-of-parameters-required": {
+        "title": "ONE_OF_PARAMETERS_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/one-of-parameters-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/one-of-parameters-required-description"
+          }
+        }
+      },
+      "alias-declined-by-processor": {
+        "title": "ALIAS_DECLINED_BY_PROCESSOR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/alias-declined-by-processor-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/alias-declined-by-processor-description"
+          }
+        }
+      },
+      "blik-one-click-missing-required-parameter": {
+        "title": "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/blik-one-click-missing-required-parameter-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/one-click-first-transaction-params"
+          }
+        }
+      },
+      "error400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "error401-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "error403-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "error404-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "error409-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "error415-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "error422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/error_details"
+        }
+      },
+      "payer-base-email-address": {
+        "description": "The email address of the payer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "payer-base-payer-id": {
+        "description": "The PayPal-assigned ID for the payer.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/account_id"
+          }
+        ]
+      },
+      "phone-with-type-phone-number": {
+        "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Supports only the `national_number` property.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone"
+          }
+        ]
+      },
+      "address-details": {
+        "type": "object",
+        "title": "Non-portable Additional Address Details",
+        "description": "The non-portable additional address details that are sometimes needed for compliance, risk, or other scenarios where fine-grain address information might be needed. Not portable with common third party and open source. Redundant with core fields.<br/>For example, `address_portable.address_line_1` is usually a combination of `address_details.street_number`, `street_name`, and `street_type`.",
+        "properties": {
+          "street_number": {
+            "type": "string",
+            "description": "The street number.",
+            "maxLength": 100
+          },
+          "street_name": {
+            "type": "string",
+            "description": "The street name. Just `Drury` in `Drury Lane`.",
+            "maxLength": 100
+          },
+          "street_type": {
+            "type": "string",
+            "description": "The street type. For example, avenue, boulevard, road, or expressway.",
+            "maxLength": 100
+          },
+          "delivery_service": {
+            "type": "string",
+            "description": "The delivery service. Post office box, bag number, or post office name.",
+            "maxLength": 100
+          },
+          "building_name": {
+            "type": "string",
+            "description": "A named locations that represents the premise. Usually a building name or number or collection of buildings with a common name or number. For example, <code>Craven House</code>.",
+            "maxLength": 100
+          },
+          "sub_building": {
+            "type": "string",
+            "description": "The first-order entity below a named building or location that represents the sub-premises. Usually a single building within a collection of buildings with a common name. Can be a flat, story, floor, room, or apartment.",
+            "maxLength": 100
+          }
+        }
+      },
+      "payer-allof1": {
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/payer-allof1-name"
+          },
+          "phone": {
+            "$ref": "#/components/schemas/payer-allof1-phone"
+          },
+          "birth_date": {
+            "$ref": "#/components/schemas/payer-allof1-birth-date"
+          },
+          "tax_info": {
+            "$ref": "#/components/schemas/payer-allof1-tax-info"
+          },
+          "address": {
+            "$ref": "#/components/schemas/payer-allof1-address"
+          }
+        }
+      },
+      "payer-allof1-name": {
+        "description": "The name of the payer. Supports only the `given_name` and `surname` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/name"
+          }
+        ]
+      },
+      "payer-allof1-phone": {
+        "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone_with_type"
+          }
+        ]
+      },
+      "payer-allof1-birth-date": {
+        "description": "The birth date of the payer in `YYYY-MM-DD` format.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_no_time"
+          }
+        ]
+      },
+      "payer-allof1-tax-info": {
+        "description": "The tax information of the payer. Required only for Brazilian payer's. Both `tax_id` and `tax_id_type` are required.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/tax_info"
+          }
+        ]
+      },
+      "payer-allof1-address": {
+        "description": "The address of the payer. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable"
+          }
+        ]
+      },
+      "amount-breakdown-item-total": {
+        "description": "The subtotal for all items. Required if the request includes `purchase_units[].items[].unit_amount`. Must equal the sum of `(items[].unit_amount * items[].quantity)` for all items. <code>item_total.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-breakdown-shipping": {
+        "description": "The shipping fee for all items within a given `purchase_unit`. <code>shipping.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-breakdown-handling": {
+        "description": "The handling fee for all items within a given `purchase_unit`. <code>handling.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-breakdown-tax-total": {
+        "description": "The total tax for all items. Required if the request includes `purchase_units.items.tax`. Must equal the sum of `(items[].tax * items[].quantity)` for all items. <code>tax_total.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-breakdown-insurance": {
+        "description": "The insurance fee for all items within a given `purchase_unit`. <code>insurance.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-breakdown-shipping-discount": {
+        "description": "The shipping discount for all items within a given `purchase_unit`. <code>shipping_discount.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-breakdown-discount": {
+        "description": "The discount for all items within a given `purchase_unit`. <code>discount.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "amount-with-breakdown-allof1": {
+        "properties": {
+          "breakdown": {
+            "$ref": "#/components/schemas/amount_breakdown"
+          }
+        }
+      },
+      "payee-base-email-address": {
+        "description": "The email address of merchant.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "payee-base-merchant-id": {
+        "description": "The encrypted PayPal account ID of the merchant.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/account_id"
+          }
+        ]
+      },
+      "platform-fee-amount": {
+        "description": "The fee for this transaction.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "platform-fee-payee": {
+        "description": "The recipient of the fee for this transaction. If you omit this value, the default is the API caller.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payee_base"
+          }
+        ]
+      },
+      "payment-instruction-platform-fees": {
+        "type": "array",
+        "description": "An array of various fees, commissions, tips, or donations. This field is only applicable to merchants that been enabled for PayPal Commerce Platform for Marketplaces and Platforms capability.",
+        "minItems": 0,
+        "maxItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/platform_fee"
+        }
+      },
+      "payment-instruction-disbursement-mode": {
+        "description": "The funds that are held payee by the marketplace/platform. This field is only applicable to merchants that been enabled for PayPal Commerce Platform for Marketplaces and Platforms capability.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/disbursement_mode"
+          }
+        ]
+      },
+      "item-unit-amount": {
+        "description": "The item price or rate per unit. If you specify <code>unit_amount</code>, <code>purchase_units[].amount.breakdown.item_total</code> is required. Must equal <code>unit_amount * quantity</code> for all items. <code>unit_amount.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "item-tax": {
+        "description": "The item tax for each unit. If <code>tax</code> is specified, <code>purchase_units[].amount.breakdown.tax_total</code> is required. Must equal <code>tax * quantity</code> for all items. <code>tax.value</code> can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "shipping-option-type": {
+        "description": "The method by which the payer wants to get their items.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/shipping_type"
+          }
+        ]
+      },
+      "shipping-option-amount": {
+        "description": "The shipping cost for the selected option.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "shipping-detail-name": {
+        "description": "The name of the person to whom to ship the items. Supports only the `full_name` property.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/name"
+          }
+        ]
+      },
+      "shipping-detail-options": {
+        "type": "array",
+        "description": "An array of shipping options that the payee or merchant offers to the payer to ship or pick up their items.",
+        "minItems": 0,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/shipping-detail-options-items"
+        }
+      },
+      "shipping-detail-options-items": {
+        "description": "The option that the payee or merchant offers to the payer to ship or pick up their items.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/shipping_option"
+          }
+        ]
+      },
+      "shipping-detail-address": {
+        "description": "The address of the person to whom to ship the items. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable"
+          }
+        ]
+      },
+      "level2-card-processing-data-tax-total": {
+        "description": "Use this field to break down the amount of tax included in the total purchase amount. The value provided here will not add to the total purchase amount. The value can't be negative, and in most cases, it must be greater than zero in order to qualify for lower interchange rates. \n Value, by country, is:\n\n    UK. A county.\n    US. A state.\n    Canada. A province.\n    Japan. A prefecture.\n    Switzerland. A kanton.\n",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "line-item-allof1": {
+        "properties": {
+          "commodity_code": {
+            "type": "string",
+            "description": "Code used to classify items purchased and track the total amount spent across various categories of products and services. Different corporate purchasing organizations may use different standards, but the United Nations Standard Products and Services Code (UNSPSC) is frequently used.",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-zA-Z0-9_'.-]*$"
+          },
+          "discount_amount": {
+            "$ref": "#/components/schemas/line-item-allof1-discount-amount"
+          },
+          "total_amount": {
+            "$ref": "#/components/schemas/line-item-allof1-total-amount"
+          },
+          "unit_of_measure": {
+            "type": "string",
+            "description": "Unit of measure is a standard used to express the magnitude of a quantity in international trade. Most commonly used (but not limited to) examples are: Acre (ACR), Ampere (AMP), Centigram (CGM), Centimetre (CMT), Cubic inch (INQ), Cubic metre (MTQ), Fluid ounce (OZA), Foot (FOT), Hour (HUR), Item (ITM), Kilogram (KGM), Kilometre (KMT), Kilowatt (KWT), Liquid gallon (GLL), Liter (LTR), Pounds (LBS), Square foot (FTK).",
+            "minLength": 1,
+            "maxLength": 12,
+            "pattern": "^[a-zA-Z0-9_'.-]*$"
+          }
+        }
+      },
+      "line-item-allof1-discount-amount": {
+        "description": "Use this field to break down the discount amount included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "line-item-allof1-total-amount": {
+        "description": "The subtotal for all items. Must equal the sum of (items[].unit_amount * items[].quantity) for all items. item_total.value can not be a negative number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "level3-card-processing-data-shipping-amount": {
+        "description": "Use this field to break down the shipping cost included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "level3-card-processing-data-duty-amount": {
+        "description": "Use this field to break down the duty amount included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "level3-card-processing-data-discount-amount": {
+        "description": "Use this field to break down the discount amount included in the total purchase amount. The value provided here will not add to the total purchase amount. The value cannot be negative.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "level3-card-processing-data-shipping-address": {
+        "description": "The address of the person to whom to ship the items. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable"
+          }
+        ]
+      },
+      "level3-card-processing-data-line-items": {
+        "type": "array",
+        "description": "A list of the items that were purchased with this payment. If your merchant account has been configured for Level 3 processing this field will be passed to the processor on your behalf.",
+        "minItems": 1,
+        "maxItems": 100,
+        "items": {
+          "$ref": "#/components/schemas/line_item"
+        }
+      },
+      "supplementary-data-card": {
+        "description": "Merchants and partners can add Level 2 and 3 data to payments to reduce risk and payment processing costs. For more information about processing payments, see <a href=\"https://developer.paypal.com/docs/checkout/advanced/processing/\">checkout</a> or <a href=\"https://developer.paypal.com/docs/multiparty/checkout/advanced/processing/\">multiparty checkout</a>.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_supplementary_data"
+          }
+        ]
+      },
+      "purchase-unit-request-amount": {
+        "description": "The total order amount with an optional breakdown that provides details, such as the total item amount, total tax amount, shipping, handling, insurance, and discounts, if any.<br/>If you specify `amount.breakdown`, the amount equals `item_total` plus `tax_total` plus `shipping` plus `handling` plus `insurance` minus `shipping_discount` minus discount.<br/>The amount must be a positive number. The `amount.value` field supports up to 15 digits preceding the decimal. For a list of supported currencies, decimal precision, and maximum charge amount, see the PayPal REST APIs <a href=\"https://developer.paypal.com/api/rest/reference/currency-codes/\">Currency Codes</a>.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/amount_with_breakdown"
+          }
+        ]
+      },
+      "purchase-unit-request-payee": {
+        "description": "The merchant who receives payment for this transaction.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payee"
+          }
+        ]
+      },
+      "purchase-unit-request-items": {
+        "type": "array",
+        "description": "An array of items that the customer purchases from the merchant.",
+        "items": {
+          "$ref": "#/components/schemas/purchase-unit-request-items-items"
+        }
+      },
+      "purchase-unit-request-items-items": {
+        "description": "The item.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/item"
+          }
+        ]
+      },
+      "purchase-unit-request-shipping": {
+        "description": "The name and address of the person to whom to ship the items.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/shipping_detail"
+          }
+        ]
+      },
+      "purchase-unit-request-supplementary-data": {
+        "description": "Contains Supplementary Data.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/supplementary_data"
+          }
+        ]
+      },
+      "customer-email-address": {
+        "description": "Email address of the buyer as provided to the merchant or on file with the merchant. Email Address is required if you are processing the transaction using PayPal Guest Processing which is offered to select partners and merchants. For all other use cases we do not expect partners/merchant to send email_address of their customer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "customer-phone": {
+        "description": "The phone number of the buyer as provided to the merchant or on file with the merchant. The `phone.phone_number` supports only `national_number`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone_with_type"
+          }
+        ]
+      },
+      "card-attributes-vault": {
+        "description": "Instruction to vault the card based on the specified strategy.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_instruction_base"
+          }
+        ]
+      },
+      "card-id": {
+        "description": "The PayPal-generated ID for the card.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/instrument_id"
+          }
+        ]
+      },
+      "card-expiry": {
+        "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_year_month"
+          }
+        ]
+      },
+      "card-card-type": {
+        "description": "The card brand or network. Typically used in the response.",
+        "readOnly": true,
+        "deprecated": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_brand"
+          }
+        ]
+      },
+      "card-type": {
+        "description": "The payment card type.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_type"
+          }
+        ]
+      },
+      "card-brand": {
+        "description": "The card brand or network. Typically used in the response.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_brand"
+          }
+        ]
+      },
+      "card-billing-address": {
+        "description": "The billing address for this card. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable"
+          }
+        ]
+      },
+      "card-attributes": {
+        "description": "Additional attributes associated with the use of this card.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_attributes"
+          }
+        ]
+      },
+      "network-transaction-reference-network": {
+        "description": "Name of the card network through which the transaction was routed.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_brand"
+          }
+        ]
+      },
+      "network-token-request-expiry": {
+        "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_year_month"
+          }
+        ]
+      },
+      "card-experience-context-return-url": {
+        "description": "The URL where the customer will be redirected upon successfully completing the 3DS challenge.",
+        "format": "uri",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/url"
+          }
+        ]
+      },
+      "card-experience-context-cancel-url": {
+        "description": "The URL where the customer will be redirected upon cancelling the 3DS challenge.",
+        "format": "uri",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/url"
+          }
+        ]
+      },
+      "card-request-allof1": {
+        "properties": {
+          "vault_id": {
+            "$ref": "#/components/schemas/card-request-allof1-vault-id"
+          },
+          "stored_credential": {
+            "$ref": "#/components/schemas/card_stored_credential"
+          },
+          "network_token": {
+            "$ref": "#/components/schemas/card-request-allof1-network-token"
+          },
+          "experience_context": {
+            "$ref": "#/components/schemas/card_experience_context"
+          }
+        }
+      },
+      "card-request-allof1-vault-id": {
+        "description": "The PayPal-generated ID for the saved card payment source. Typically stored on the merchant's server.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_id"
+          }
+        ]
+      },
+      "card-request-allof1-network-token": {
+        "description": "A 3rd party network token refers to a network token that the merchant provisions from and vaults with an external TSP (Token Service Provider) other than PayPal.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/network_token_request"
+          }
+        ]
+      },
+      "address-details1": {
+        "type": "object",
+        "title": "Address Details",
+        "description": "The non-portable additional address details include fine-grain address information for Compliance, Risk, and other scenarios. This isn't portable with common third-party and open source applications. This can include data that is redundant with core fields. For example, `address_portable.address_line_1` is usually a combination of `address_details.street_number`, `street_name`, and `street_type`.",
+        "properties": {
+          "street_number": {
+            "type": "string",
+            "description": "The street number.",
+            "maxLength": 100
+          },
+          "street_name": {
+            "type": "string",
+            "description": "The street name. Just `Drury` in `Drury Lane`.",
+            "maxLength": 100
+          },
+          "street_type": {
+            "type": "string",
+            "description": "The street type. For example, avenue, boulevard, road, or expressway.",
+            "maxLength": 100
+          },
+          "delivery_service": {
+            "type": "string",
+            "description": "The delivery service. Post office box, bag number, or post office name.",
+            "maxLength": 100
+          },
+          "building_name": {
+            "type": "string",
+            "description": "A named locations that represents the premise. Usually a building name or number or collection of buildings with a common name or number. For example, <code>Craven House</code>.",
+            "maxLength": 100
+          },
+          "sub_building": {
+            "type": "string",
+            "description": "The first-order entity below a named building or location that represents the sub-premise. Usually a single building within a collection of buildings with a common name. Can be a flat, story, floor, room, or apartment.",
+            "maxLength": 100
+          }
+        }
+      },
+      "vault-paypal-wallet-base-allof1": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description displayed to PayPal consumer on the approval flow for PayPal, as well as on the PayPal payment token management experience on PayPal.com.",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "usage_pattern": {
+            "$ref": "#/components/schemas/vault-paypal-wallet-base-allof1-usage-pattern"
+          },
+          "shipping": {
+            "$ref": "#/components/schemas/vault-paypal-wallet-base-allof1-shipping"
+          },
+          "usage_type": {
+            "$ref": "#/components/schemas/vault-paypal-wallet-base-allof1-usage-type"
+          },
+          "customer_type": {
+            "$ref": "#/components/schemas/vault-paypal-wallet-base-allof1-customer-type"
+          },
+          "permit_multiple_payment_tokens": {
+            "type": "boolean",
+            "description": "Create multiple payment tokens for the same payer, merchant/platform combination. Use this when the customer has not logged in at merchant/platform. The payment token thus generated, can then also be used to create the customer account at merchant/platform. Use this also when multiple payment tokens are required for the same payer, different customer at merchant/platform. This helps to identify customers distinctly even though they may share the same PayPal account. This only applies to PayPal payment source.",
+            "default": false
+          }
+        }
+      },
+      "vault-paypal-wallet-base-allof1-shipping": {
+        "description": "The shipping address for the Payer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/shipping_detail"
+          }
+        ]
+      },
+      "paypal-wallet-attributes-vault": {
+        "description": "Attributes used to provide the instructions during vaulting of the PayPal Wallet.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_paypal_wallet_base"
+          }
+        ]
+      },
+      "paypal-wallet-experience-context-locale": {
+        "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/language"
+          }
+        ]
+      },
+      "paypal-wallet-experience-context-return-url": {
+        "description": "The URL where the customer will be redirected upon approving a payment.",
+        "format": "uri",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/url"
+          }
+        ]
+      },
+      "paypal-wallet-experience-context-cancel-url": {
+        "description": "The URL where the customer will be redirected upon cancelling the payment approval.",
+        "format": "uri",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/url"
+          }
+        ]
+      },
+      "paypal-wallet-vault-id": {
+        "description": "The PayPal-generated ID for the payment_source stored within the Vault.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_id"
+          }
+        ]
+      },
+      "paypal-wallet-email-address": {
+        "description": "The email address of the PayPal account holder.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "paypal-wallet-name": {
+        "description": "The name of the PayPal account holder. Supports only the `given_name` and `surname` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/name-2"
+          }
+        ]
+      },
+      "paypal-wallet-phone": {
+        "description": "The phone number of the customer. Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. The `phone.phone_number` supports only `national_number`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone_with_type"
+          }
+        ]
+      },
+      "paypal-wallet-birth-date": {
+        "description": "The birth date of the PayPal account holder in `YYYY-MM-DD` format.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_no_time"
+          }
+        ]
+      },
+      "paypal-wallet-tax-info": {
+        "description": "The tax information of the PayPal account holder. Required only for Brazilian PayPal account holder's. Both `tax_id` and `tax_id_type` are required.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/tax_info"
+          }
+        ]
+      },
+      "paypal-wallet-address": {
+        "description": "The address of the PayPal account holder. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable-2"
+          }
+        ]
+      },
+      "paypal-wallet-attributes": {
+        "description": "Additional attributes associated with the use of this wallet.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/paypal_wallet_attributes"
+          }
+        ]
+      },
+      "experience-context-base-locale": {
+        "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/language"
+          }
+        ]
+      },
+      "experience-context-base-return-url": {
+        "description": "The URL where the customer is redirected after the customer approves the payment.",
+        "format": "uri",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/url"
+          }
+        ]
+      },
+      "experience-context-base-cancel-url": {
+        "description": "The URL where the customer is redirected after the customer cancels the payment.",
+        "format": "uri",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/url"
+          }
+        ]
+      },
+      "bancontact-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "bancontact-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "bancontact-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "bancontact-request-attributes": {
+        "description": "Attributes for altpay recurring.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/altpay_recurring_attributes_request"
+          }
+        ]
+      },
+      "blik-experience-context-allof1": {
+        "properties": {
+          "consumer_ip": {
+            "$ref": "#/components/schemas/blik-experience-context-allof1-consumer-ip"
+          },
+          "consumer_user_agent": {
+            "type": "string",
+            "description": "The payer's User Agent. For example, Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0).",
+            "minLength": 1,
+            "maxLength": 256,
+            "pattern": "^.*$"
+          }
+        }
+      },
+      "blik-experience-context-allof1-consumer-ip": {
+        "description": "The IP address of the consumer. It could be either IPv4 or IPv6.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ip_address"
+          }
+        ]
+      },
+      "blik-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "blik-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "blik-request-email": {
+        "description": "The email address of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email_address"
+          }
+        ]
+      },
+      "blik-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/blik_experience_context"
+          }
+        ]
+      },
+      "blik-request-level0": {
+        "description": "The level_0 integration flow object.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/blik_seamless"
+          }
+        ]
+      },
+      "blik-request-one-click": {
+        "description": "The one-click integration flow object.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/blik_one_click"
+          }
+        ]
+      },
+      "eps-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "eps-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "eps-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "giropay-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "giropay-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "giropay-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "ideal-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "ideal-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "ideal-request-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "ideal-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "ideal-request-attributes": {
+        "description": "Attributes for altpay recurring.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/altpay_recurring_attributes_request"
+          }
+        ]
+      },
+      "mybank-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "mybank-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "mybank-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "p24-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "p24-request-email": {
+        "description": "The email address of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email_address"
+          }
+        ]
+      },
+      "p24-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "p24-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "sofort-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "sofort-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "sofort-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "trustly-request-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "trustly-request-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "trustly-request-experience-context": {
+        "description": "Customizes the payer experience during the approval process for the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/experience_context_base"
+          }
+        ]
+      },
+      "apple-pay-decrypted-token-data-transaction-amount": {
+        "description": "The transaction amount for the payment that the payer has approved on apple platform.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money-2"
+          }
+        ]
+      },
+      "apple-pay-decrypted-token-data-tokenized-card": {
+        "description": "Apple Pay tokenized credit card used to pay.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card"
+          }
+        ]
+      },
+      "apple-pay-decrypted-token-data-payment-data": {
+        "description": "Apple Pay payment data object which contains the cryptogram, eci_indicator and other data.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/apple_pay_payment_data"
+          }
+        ]
+      },
+      "apple-pay-request-name": {
+        "description": "Name on the account holder associated with apple pay.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "apple-pay-request-email-address": {
+        "description": "The email address of the account holder associated with apple pay.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email_address"
+          }
+        ]
+      },
+      "apple-pay-request-phone-number": {
+        "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Supports only the `national_number` property.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone"
+          }
+        ]
+      },
+      "apple-pay-request-decrypted-token": {
+        "description": "The decrypted payload details for the apple pay token.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/apple_pay_decrypted_token_data"
+          }
+        ]
+      },
+      "apple-pay-request-vault-id": {
+        "description": "The PayPal-generated ID for the saved apple pay payment_source. This ID should be stored on the merchant's server so the saved payment source can be used for future transactions.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_id"
+          }
+        ]
+      },
+      "vault-venmo-wallet-base-allof1": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description displayed to Venmo consumer on the approval flow for Venmo, as well as on the Venmo payment token management experience on Venmo.com.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[a-zA-Z0-9_'\\-., :;\\!?\"]*$"
+          },
+          "usage_pattern": {
+            "$ref": "#/components/schemas/vault-venmo-wallet-base-allof1-usage-pattern"
+          },
+          "usage_type": {
+            "$ref": "#/components/schemas/vault-venmo-wallet-base-allof1-usage-type"
+          },
+          "customer_type": {
+            "$ref": "#/components/schemas/vault-venmo-wallet-base-allof1-customer-type"
+          },
+          "permit_multiple_payment_tokens": {
+            "type": "boolean",
+            "description": "Create multiple payment tokens for the same payer, merchant/platform combination. Use this when the customer has not logged in at merchant/platform. The payment token thus generated, can then also be used to create the customer account at merchant/platform. Use this also when multiple payment tokens are required for the same payer, different customer at merchant/platform. This helps to identify customers distinctly even though they may share the same Venmo account.",
+            "default": false
+          }
+        }
+      },
+      "venmo-wallet-attributes-vault": {
+        "description": "Attributes used to provide the instructions during vaulting of the Venmo Wallet.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_venmo_wallet_base"
+          }
+        ]
+      },
+      "venmo-wallet-request-vault-id": {
+        "description": "The PayPal-generated ID for the saved Venmo wallet payment_source. This ID should be stored on the merchant's server so the saved payment source can be used for future transactions.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/vault_id"
+          }
+        ]
+      },
+      "venmo-wallet-request-email-address": {
+        "description": "The email address of the payer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "venmo-wallet-request-attributes": {
+        "description": "Additional attributes associated with the use of this wallet.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/venmo_wallet_attributes"
+          }
+        ]
+      },
+      "payment-source-paypal": {
+        "description": "Indicates that PayPal Wallet is the payment source. Main use of this selection is to provide additional instructions associated with this choice like vaulting.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/paypal_wallet"
+          }
+        ]
+      },
+      "payment-source-bancontact": {
+        "description": "Bancontact is the most popular online payment in Belgium. [More Details](https://www.bancontact.com/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bancontact_request"
+          }
+        ]
+      },
+      "payment-source-blik": {
+        "description": "BLIK is a mobile payment system, created by Polish Payment Standard in order to allow millions of users to pay in shops, payout cash in ATMs and make online purchases and payments. [More Details](https://blikmobile.pl/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/blik_request"
+          }
+        ]
+      },
+      "payment-source-eps": {
+        "description": "The eps transfer is an online payment method developed by many Austrian banks. [More Details](https://www.eps-ueberweisung.at/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/eps_request"
+          }
+        ]
+      },
+      "payment-source-giropay": {
+        "description": "Giropay is an Internet payment System in Germany, based on online banking. [More Details](https://giropay.de/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/giropay_request"
+          }
+        ]
+      },
+      "payment-source-ideal": {
+        "description": "The Dutch payment method iDEAL is an online payment method that enables consumers to pay online through their own bank. [More Details](https://www.ideal.nl/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ideal_request"
+          }
+        ]
+      },
+      "payment-source-mybank": {
+        "description": "MyBank is an e-authorisation solution which enables safe digital payments and identity authentication through a consumer’s own online banking portal or mobile application. [More Details](https://www.mybank.eu/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/mybank_request"
+          }
+        ]
+      },
+      "payment-source-p24": {
+        "description": "P24 (Przelewy24) is a secure and fast online bank transfer service linked to all the major banks in Poland. [More Details](https://www.przelewy24.pl/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/p24_request"
+          }
+        ]
+      },
+      "payment-source-sofort": {
+        "description": "SOFORT Banking is a real-time bank transfer payment method that buyers use to transfer funds directly to merchants from their bank accounts. [More Details](https://www.klarna.com/sofort/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/sofort_request"
+          }
+        ]
+      },
+      "payment-source-trustly": {
+        "description": "Trustly is a payment method that allows customers to shop and pay from their bank account. [More Details](https://www.trustly.net/).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/trustly_request"
+          }
+        ]
+      },
+      "payment-source-apple-pay": {
+        "description": "ApplePay payment source, allows buyer to pay using ApplePay, both on Web as well as on Native.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/apple_pay_request"
+          }
+        ]
+      },
+      "payment-source-google-pay": {
+        "description": "Google Pay payment source, allows buyer to pay using Google Pay.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/google_pay_request"
+          }
+        ]
+      },
+      "payment-source-venmo": {
+        "description": "Information needed to indicate that Venmo is being used to fund the payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/venmo_wallet_request"
+          }
+        ]
+      },
+      "order-application-context-locale": {
+        "description": "DEPRECATED. The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.locale`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/language"
+          }
+        ]
+      },
+      "order-application-context-payment-method": {
+        "description": "DEPRECATED. The customer and merchant payment preferences. The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.payment_method_selected`). Please specify this field in the `experience_context` object instead of the `application_context` object..",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payment_method"
+          }
+        ]
+      },
+      "order-application-context-stored-payment-source": {
+        "description": "DEPRECATED. Provides additional details to process a payment using a `payment_source` that has been stored or is intended to be stored (also referred to as stored_credential or card-on-file).<br/>Parameter compatibility:<br/><ul><li>`payment_type=ONE_TIME` is compatible only with `payment_initiator=CUSTOMER`.</li><li>`usage=FIRST` is compatible only with `payment_initiator=CUSTOMER`.</li><li>`previous_transaction_reference` or `previous_network_transaction_reference` is compatible only with `payment_initiator=MERCHANT`.</li><li>Only one of the parameters - `previous_transaction_reference` and `previous_network_transaction_reference` - can be present in the request.</li></ul>.  The fields in `stored_payment_source` are now available in the `stored_credential` object under the `payment_source` which supports them (eg. `payment_source.card.stored_credential.payment_initiator`). Please specify this field in the `payment_source` object instead of the `application_context` object.",
+        "deprecated": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/stored_payment_source"
+          }
+        ]
+      },
+      "order-request-payer": {
+        "description": "DEPRECATED. The customer is also known as the payer. The Payer object was intended to only be used with the `payment_source.paypal` object. In order to make this design more clear, the details in the `payer` object are now available under `payment_source.paypal`. Please use `payment_source.paypal`.",
+        "deprecated": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payer"
+          }
+        ]
+      },
+      "order-request-purchase-units": {
+        "type": "array",
+        "description": "An array of purchase units. Each purchase unit establishes a contract between a payer and the payee. Each purchase unit represents either a full or partial order that the payer intends to purchase from the payee.",
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/order-request-purchase-units-items"
+        }
+      },
+      "order-request-purchase-units-items": {
+        "description": "The purchase unit. Establishes a contract between a payer and the payee.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/purchase_unit_request"
+          }
+        ]
+      },
+      "order-request-application-context": {
+        "description": "Customize the payer experience during the approval process for the payment with PayPal.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/order_application_context"
+          }
+        ]
+      },
+      "activity-timestamps-create-time": {
+        "description": "The date and time when the transaction occurred, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_time"
+          }
+        ]
+      },
+      "activity-timestamps-update-time": {
+        "description": "The date and time when the transaction was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_time"
+          }
+        ]
+      },
+      "3ds-auth-response-auth-status": {
+        "description": "The outcome of the issuer's authentication.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/pares_status"
+          }
+        ]
+      },
+      "3ds-auth-response-enrollment-status": {
+        "description": "Status of authentication eligibility.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/enrolled"
+          }
+        ]
+      },
+      "authentication-response-exemption-details": {
+        "description": "Exemption details of 3D Secure Authentication.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/exemption_details"
+          }
+        ]
+      },
+      "vault-response-links": {
+        "type": "array",
+        "description": "An array of request-related HATEOAS links.",
+        "readOnly": true,
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/vault-response-links-items"
+        }
+      },
+      "vault-response-links-items": {
+        "description": "A request-related [HATEOAS link](/docs/api/reference/api-responses/#hateoas-links).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/link_description"
+          }
+        ]
+      },
+      "card-from-request-expiry": {
+        "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_year_month"
+          }
+        ]
+      },
+      "bin-details-bin-country-code": {
+        "description": "The [two-character ISO-3166-1 country code](/docs/integration/direct/rest/country-codes/) of the bank.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "bin-details-products": {
+        "type": "array",
+        "description": "The type of card product assigned to the BIN by the issuer. These values are defined by the issuer and may change over time. Some examples include: PREPAID_GIFT, CONSUMER, CORPORATE.",
+        "items": {
+          "type": "string",
+          "description": "This value provides the category of the BIN.",
+          "minLength": 1,
+          "maxLength": 255
+        },
+        "minItems": 1,
+        "maxItems": 256
+      },
+      "card-response-brand": {
+        "description": "The card brand or network. Typically used in the response.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/card_brand"
+          }
+        ]
+      },
+      "card-response-available-networks": {
+        "type": "array",
+        "description": "Array of brands or networks associated with the card.",
+        "readOnly": true,
+        "minItems": 1,
+        "maxItems": 256,
+        "items": {
+          "$ref": "#/components/schemas/card_brand"
+        }
+      },
+      "card-response-expiry": {
+        "description": "The card expiration year and month, in [Internet date format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_year_month"
+          }
+        ]
+      },
+      "card-response-bin-details": {
+        "description": "Bank Identification Number (BIN) details used to fund a payment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bin_details"
+          }
+        ]
+      },
+      "cobranded-card-labels": {
+        "type": "array",
+        "description": "Array of labels for the cobranded card.",
+        "minItems": 1,
+        "maxItems": 25,
+        "items": {
+          "type": "string",
+          "description": "Label for the cobranded card.",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "cobranded-card-payee": {
+        "description": "Merchant associated with the purchase.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payee_base"
+          }
+        ]
+      },
+      "cobranded-card-amount": {
+        "description": "Amount that was charged to the cobranded card.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "paypal-wallet-attributes-response-cobranded-cards": {
+        "type": "array",
+        "description": "An array of merchant cobranded cards used by buyer to complete an order. This array will be present if a merchant has onboarded their cobranded card with PayPal and provided corresponding label(s).",
+        "minItems": 0,
+        "maxItems": 25,
+        "items": {
+          "$ref": "#/components/schemas/cobranded_card"
+        }
+      },
+      "paypal-wallet-response-email-address": {
+        "description": "The email address of the PayPal account holder.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "paypal-wallet-response-account-id": {
+        "description": "The PayPal-assigned ID for the PayPal account holder.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/account_id-2"
+          }
+        ]
+      },
+      "paypal-wallet-response-name": {
+        "description": "The name of the PayPal account holder. Supports only the `given_name` and `surname` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/name-2"
+          }
+        ]
+      },
+      "paypal-wallet-response-phone-number": {
+        "description": "The phone number, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Available only when you enable the **Contact Telephone Number** option in the <a href=\"https://www.paypal.com/cgi-bin/customerprofileweb?cmd=_profile-website-payments\">**Profile & Settings**</a> for the merchant's PayPal account. Supports only the `national_number` property.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone-2"
+          }
+        ]
+      },
+      "paypal-wallet-response-birth-date": {
+        "description": "The birth date of the PayPal account holder in `YYYY-MM-DD` format.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_no_time"
+          }
+        ]
+      },
+      "paypal-wallet-response-tax-info": {
+        "description": "The tax information of the PayPal account holder. Required only for Brazilian PayPal account holder's. Both `tax_id` and `tax_id_type` are required.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/tax_info"
+          }
+        ]
+      },
+      "paypal-wallet-response-address": {
+        "description": "The address of the PayPal account holder. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable-2"
+          }
+        ]
+      },
+      "bancontact-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "bancontact-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "bancontact-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "bancontact-attributes": {
+        "description": "Attributes for SEPA direct debit object.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/altpay_recurring_attributes"
+          }
+        ]
+      },
+      "blik-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "blik-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "blik-email": {
+        "description": "The email address of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email_address"
+          }
+        ]
+      },
+      "blik-one-click": {
+        "description": "The one-click integration flow object.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/blik_one_click_response"
+          }
+        ]
+      },
+      "eps-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "eps-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "eps-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "giropay-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "giropay-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "giropay-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "ideal-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "ideal-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "ideal-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "ideal-attributes": {
+        "description": "Attributes for SEPA direct debit object.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/altpay_recurring_attributes"
+          }
+        ]
+      },
+      "mybank-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "mybank-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "mybank-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "p24-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "p24-email": {
+        "description": "The email address of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email_address"
+          }
+        ]
+      },
+      "p24-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "sofort-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "sofort-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "sofort-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "trustly-name": {
+        "description": "The name of the account holder associated with this payment method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/full_name"
+          }
+        ]
+      },
+      "trustly-country-code": {
+        "description": "The two-character ISO 3166-1 country code.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/country_code"
+          }
+        ]
+      },
+      "trustly-bic": {
+        "description": "The bank identification code (BIC).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/bic"
+          }
+        ]
+      },
+      "venmo-wallet-response-email-address": {
+        "description": "The email address of the payer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/email"
+          }
+        ]
+      },
+      "venmo-wallet-response-account-id": {
+        "description": "This is an immutable system-generated id for a user's Venmo account.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/account_id-2"
+          }
+        ]
+      },
+      "venmo-wallet-response-name": {
+        "description": "The name associated with the Venmo account. Supports only the `given_name` and `surname` properties.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/name-2"
+          }
+        ]
+      },
+      "venmo-wallet-response-phone-number": {
+        "description": "The phone number associated with the Venmo account, in its canonical international [E.164 numbering plan format](https://www.itu.int/rec/T-REC-E.164/en). Supports only the `national_number` property.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/phone-2"
+          }
+        ]
+      },
+      "venmo-wallet-response-address": {
+        "description": "The address of the payer. Supports only the `address_line_1`, `address_line_2`, `admin_area_1`, `admin_area_2`, `postal_code`, and `country_code` properties. Also referred to as the billing address of the customer.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/address_portable-2"
+          }
+        ]
+      },
+      "tracker-item-upc": {
+        "description": "The Universal Product Code of the item.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/universal_product_code"
+          }
+        ]
+      },
+      "tracker-allof0": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The tracker id.",
+            "readOnly": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/tracker_status"
+          },
+          "items": {
+            "$ref": "#/components/schemas/tracker-allof0-items"
+          },
+          "links": {
+            "$ref": "#/components/schemas/tracker-allof0-links"
+          }
+        }
+      },
+      "tracker-allof0-items": {
+        "type": "array",
+        "description": "An array of details of items in the shipment.",
+        "items": {
+          "$ref": "#/components/schemas/tracker-allof0-items-items"
+        }
+      },
+      "tracker-allof0-items-items": {
+        "description": "Items in a shipment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/tracker_item"
+          }
+        ]
+      },
+      "tracker-allof0-links": {
+        "type": "array",
+        "description": "An array of request-related HATEOAS links.",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/tracker-allof0-links-items"
+        }
+      },
+      "tracker-allof0-links-items": {
+        "description": "A request-related [HATEOAS link](/api/rest/responses/#hateoas-links).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/link_description"
+          }
+        ]
+      },
+      "shipping-with-tracking-details-allof1": {
+        "properties": {
+          "trackers": {
+            "$ref": "#/components/schemas/shipping-with-tracking-details-allof1-trackers"
+          }
+        }
+      },
+      "shipping-with-tracking-details-allof1-trackers": {
+        "type": "array",
+        "description": "An array of trackers for a transaction.",
+        "items": {
+          "$ref": "#/components/schemas/tracker"
+        }
+      },
+      "authorization-status-status-details": {
+        "description": "The details of the authorized order pending status.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/authorization_status_details"
+          }
+        ]
+      },
+      "seller-protection-dispute-categories": {
+        "type": "array",
+        "description": "An array of conditions that are covered for the transaction.",
+        "items": {
+          "$ref": "#/components/schemas/seller-protection-dispute-categories-items"
+        },
+        "readOnly": true
+      },
+      "authorization-allof1": {
+        "properties": {
+          "id": {
+            "description": "The PayPal-generated ID for the authorized payment.",
+            "type": "string",
+            "readOnly": true
+          },
+          "amount": {
+            "$ref": "#/components/schemas/authorization-allof1-amount"
+          },
+          "invoice_id": {
+            "description": "The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.",
+            "type": "string",
+            "readOnly": true
+          },
+          "custom_id": {
+            "type": "string",
+            "description": "The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. Appears in transaction and settlement reports.",
+            "maxLength": 127
+          },
+          "network_transaction_reference": {
+            "$ref": "#/components/schemas/network_transaction_reference"
+          },
+          "seller_protection": {
+            "$ref": "#/components/schemas/authorization-allof1-seller-protection"
+          },
+          "expiration_time": {
+            "$ref": "#/components/schemas/authorization-allof1-expiration-time"
+          },
+          "links": {
+            "$ref": "#/components/schemas/authorization-allof1-links"
+          }
+        }
+      },
+      "authorization-allof1-amount": {
+        "description": "The amount for this authorized payment.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "authorization-allof1-seller-protection": {
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/seller_protection"
+          }
+        ]
+      },
+      "authorization-allof1-expiration-time": {
+        "description": "The date and time when the authorized payment expires, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_time"
+          }
+        ]
+      },
+      "authorization-allof1-links": {
+        "description": "An array of related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "type": "array",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        }
+      },
+      "authorization-with-additional-data-allof1": {
+        "properties": {
+          "processor_response": {
+            "$ref": "#/components/schemas/authorization-additional-data-processor-response"
+          }
+        }
+      },
+      "authorization-additional-data-processor-response": {
+        "description": "The processor response for card transactions.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/processor_response"
+          }
+        ]
+      },
+      "capture-status-status-details": {
+        "description": "The details of the captured payment status.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/capture_status_details"
+          }
+        ]
+      },
+      "exchange-rate-source-currency": {
+        "description": "The source currency from which to convert an amount.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/currency_code"
+          }
+        ]
+      },
+      "exchange-rate-target-currency": {
+        "description": "The target currency to which to convert an amount.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/currency_code"
+          }
+        ]
+      },
+      "seller-receivable-breakdown-gross-amount": {
+        "description": "The amount for this captured payment in the currency of the transaction.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "seller-receivable-breakdown-paypal-fee": {
+        "description": "The applicable fee for this captured payment in the currency of the transaction.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "captured-payment-fee-receivable-currency": {
+        "description": "The applicable fee for this captured payment in the receivable currency. Returned only in cases the fee is charged in the receivable currency. Example 'CNY'.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "seller-receivable-breakdown-net-amount": {
+        "description": "The net amount that the payee receives for this captured payment in their PayPal account. The net amount is computed as <code>gross_amount</code> minus the <code>paypal_fee</code> minus the <code>platform_fees</code>.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "seller-receivable-breakdown-receivable-amount": {
+        "description": "The net amount that is credited to the payee's PayPal account. Returned only when the currency of the captured payment is different from the currency of the PayPal account where the payee wants to credit the funds. The amount is computed as <code>net_amount</code> times <code>exchange_rate</code>.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "seller-receivable-breakdown-exchange-rate": {
+        "description": "The exchange rate that determines the amount that is credited to the payee's PayPal account. Returned when the currency of the captured payment is different from the currency of the PayPal account where the payee wants to credit the funds.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/exchange_rate"
+          }
+        ]
+      },
+      "seller-receivable-breakdown-platform-fees": {
+        "type": "array",
+        "description": "An array of platform or partner fees, commissions, or brokerage fees that associated with the captured payment.",
+        "minItems": 0,
+        "maxItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/platform_fee"
+        }
+      },
+      "capture-allof1": {
+        "properties": {
+          "id": {
+            "description": "The PayPal-generated ID for the captured payment.",
+            "type": "string",
+            "readOnly": true
+          },
+          "amount": {
+            "$ref": "#/components/schemas/capture-allof1-amount"
+          },
+          "invoice_id": {
+            "description": "The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.",
+            "type": "string",
+            "readOnly": true
+          },
+          "custom_id": {
+            "type": "string",
+            "description": "The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. Appears in transaction and settlement reports.",
+            "maxLength": 127
+          },
+          "network_transaction_reference": {
+            "$ref": "#/components/schemas/network_transaction_reference"
+          },
+          "seller_protection": {
+            "$ref": "#/components/schemas/capture-allof1-seller-protection"
+          },
+          "final_capture": {
+            "description": "Indicates whether you can make additional captures against the authorized payment. Set to `true` if you do not intend to capture additional payments against the authorization. Set to `false` if you intend to capture additional payments against the authorization.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true
+          },
+          "seller_receivable_breakdown": {
+            "$ref": "#/components/schemas/capture-allof1-seller-receivable-breakdown"
+          },
+          "disbursement_mode": {
+            "$ref": "#/components/schemas/disbursement_mode"
+          },
+          "links": {
+            "$ref": "#/components/schemas/capture-allof1-links"
+          },
+          "processor_response": {
+            "$ref": "#/components/schemas/capture-allof1-processor-response"
+          }
+        }
+      },
+      "capture-allof1-amount": {
+        "description": "The amount for this captured payment.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "capture-allof1-seller-protection": {
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/seller_protection"
+          }
+        ]
+      },
+      "capture-allof1-seller-receivable-breakdown": {
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/seller_receivable_breakdown"
+          }
+        ]
+      },
+      "capture-allof1-links": {
+        "description": "An array of related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "type": "array",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        }
+      },
+      "capture-allof1-processor-response": {
+        "description": "An object that provides additional processor information for a direct credit card transaction.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/processor_response"
+          }
+        ]
+      },
+      "refund-status-status-details": {
+        "description": "The details of the refund status.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/refund_status_details"
+          }
+        ]
+      },
+      "net-amount-breakdown-item-payable-amount": {
+        "description": "The net amount debited from the merchant's PayPal account.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "net-amount-breakdown-item-converted-amount": {
+        "description": "The converted payable amount.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "net-amount-breakdown-item-exchange-rate": {
+        "description": "The exchange rate that determines the amount that was debited from the merchant's PayPal account.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/exchange_rate"
+          }
+        ]
+      },
+      "refund-allof1": {
+        "properties": {
+          "id": {
+            "description": "The PayPal-generated ID for the refund.",
+            "type": "string",
+            "readOnly": true
+          },
+          "amount": {
+            "$ref": "#/components/schemas/refund-allof1-amount"
+          },
+          "invoice_id": {
+            "description": "The API caller-provided external invoice number for this order. Appears in both the payer's transaction history and the emails that the payer receives.",
+            "type": "string",
+            "readOnly": true
+          },
+          "custom_id": {
+            "type": "string",
+            "description": "The API caller-provided external ID. Used to reconcile API caller-initiated transactions with PayPal transactions. Appears in transaction and settlement reports.",
+            "minLength": 1,
+            "maxLength": 127,
+            "pattern": "^[A-Za-z0-9-_.,]*$"
+          },
+          "acquirer_reference_number": {
+            "type": "string",
+            "description": "Reference ID issued for the card transaction. This ID can be used to track the transaction across processors, card brands and issuing banks.",
+            "minLength": 1,
+            "maxLength": 36,
+            "pattern": "^[a-zA-Z0-9]+$"
+          },
+          "note_to_payer": {
+            "description": "The reason for the refund. Appears in both the payer's transaction history and the emails that the payer receives.",
+            "type": "string",
+            "readOnly": true
+          },
+          "seller_payable_breakdown": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown"
+          },
+          "payer": {
+            "$ref": "#/components/schemas/refund-allof1-payer"
+          },
+          "links": {
+            "$ref": "#/components/schemas/refund-allof1-links"
+          }
+        }
+      },
+      "refund-allof1-amount": {
+        "description": "The amount that the payee refunded to the payer.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "merchant-payable-breakdown": {
+        "description": "The breakdown of the refund.",
+        "type": "object",
+        "title": "Merchant Payable Breakdown",
+        "properties": {
+          "gross_amount": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown-gross-amount"
+          },
+          "paypal_fee": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown-paypal-fee"
+          },
+          "paypal_fee_in_receivable_currency": {
+            "$ref": "#/components/schemas/refunded-fee-receivable-currency"
+          },
+          "net_amount": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown-net-amount"
+          },
+          "net_amount_in_receivable_currency": {
+            "$ref": "#/components/schemas/debited-amount-receivable-currency"
+          },
+          "platform_fees": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown-platform-fees"
+          },
+          "net_amount_breakdown": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown-net-amount-breakdown"
+          },
+          "total_refunded_amount": {
+            "$ref": "#/components/schemas/merchant-payable-breakdown-total-refunded-amount"
+          }
+        },
+        "readOnly": true
+      },
+      "merchant-payable-breakdown-gross-amount": {
+        "description": "The amount that the payee refunded to the payer.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "merchant-payable-breakdown-paypal-fee": {
+        "description": "The PayPal fee that was refunded to the payer in the currency of the transaction. This fee might not match the PayPal fee that the payee paid when the payment was captured.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "refunded-fee-receivable-currency": {
+        "description": "The PayPal fee that was refunded to the payer in the receivable currency. Returned only in cases when the receivable currency is different from transaction currency. Example 'CNY'.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "merchant-payable-breakdown-net-amount": {
+        "description": "The net amount that the payee's account is debited in the transaction currency. The net amount is calculated as <code>gross_amount</code> minus <code>paypal_fee</code> minus <code>platform_fees</code>.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "debited-amount-receivable-currency": {
+        "description": "The net amount that the payee's account is debited in the receivable currency. Returned only in cases when the receivable currency is different from transaction currency. Example 'CNY'.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "merchant-payable-breakdown-platform-fees": {
+        "type": "array",
+        "description": "An array of platform or partner fees, commissions, or brokerage fees for the refund.",
+        "minItems": 0,
+        "maxItems": 1,
+        "items": {
+          "$ref": "#/components/schemas/platform_fee"
+        }
+      },
+      "merchant-payable-breakdown-net-amount-breakdown": {
+        "type": "array",
+        "description": "An array of breakdown values for the net amount. Returned when the currency of the refund is different from the currency of the PayPal account where the payee holds their funds.",
+        "items": {
+          "$ref": "#/components/schemas/net_amount_breakdown_item"
+        },
+        "readOnly": true
+      },
+      "merchant-payable-breakdown-total-refunded-amount": {
+        "description": "The total amount refunded from the original capture to date. For example, if a payer makes a $100 purchase and was refunded $20 a week ago and was refunded $30 in this refund, the `gross_amount` is $30 for this refund and the `total_refunded_amount` is $50.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/money"
+          }
+        ]
+      },
+      "refund-allof1-payer": {
+        "description": "The details associated with the merchant for this transaction.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payee_base"
+          }
+        ]
+      },
+      "refund-allof1-links": {
+        "description": "An array of related [HATEOAS links](/docs/api/reference/api-responses/#hateoas-links).",
+        "type": "array",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/link_description"
+        }
+      },
+      "payment-collection-authorizations": {
+        "type": "array",
+        "description": "An array of authorized payments for a purchase unit. A purchase unit can have zero or more authorized payments.",
+        "items": {
+          "$ref": "#/components/schemas/payment-collection-authorizations-items"
+        }
+      },
+      "payment-collection-authorizations-items": {
+        "description": "The authorized payment for a purchase unit.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/authorization_with_additional_data"
+          }
+        ]
+      },
+      "payment-collection-captures": {
+        "type": "array",
+        "description": "An array of captured payments for a purchase unit. A purchase unit can have zero or more captured payments.",
+        "items": {
+          "$ref": "#/components/schemas/payment-collection-captures-items"
+        }
+      },
+      "payment-collection-captures-items": {
+        "description": "The captured payment for a purchase unit.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/capture"
+          }
+        ]
+      },
+      "payment-collection-refunds": {
+        "type": "array",
+        "description": "An array of refunds for a purchase unit. A purchase unit can have zero or more refunds.",
+        "items": {
+          "$ref": "#/components/schemas/payment-collection-refunds-items"
+        }
+      },
+      "payment-collection-refunds-items": {
+        "description": "A refund for a purchase unit.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/refund"
+          }
+        ]
+      },
+      "purchase-unit-payee": {
+        "description": "The merchant who receives payment for this transaction.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payee"
+          }
+        ]
+      },
+      "purchase-unit-items": {
+        "type": "array",
+        "description": "An array of items that the customer purchases from the merchant.",
+        "items": {
+          "$ref": "#/components/schemas/purchase-unit-items-items"
+        }
+      },
+      "purchase-unit-items-items": {
+        "description": "An item.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/item"
+          }
+        ]
+      },
+      "purchase-unit-shipping": {
+        "description": "The shipping address and method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/shipping_with_tracking_details"
+          }
+        ]
+      },
+      "purchase-unit-supplementary-data": {
+        "description": "Supplementary data about this payment. Merchants and partners can add Level 2 and 3 data to payments to reduce risk and payment processing costs. For more information about processing payments, see <a href=\"https://developer.paypal.com/docs/checkout/advanced/processing/\">checkout</a> or <a href=\"https://developer.paypal.com/docs/multiparty/checkout/advanced/processing/\">multiparty checkout</a>.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/supplementary_data"
+          }
+        ]
+      },
+      "purchase-unit-payments": {
+        "description": "The comprehensive history of payments for the purchase unit.",
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payment_collection"
+          }
+        ]
+      },
+      "order-allof1": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the order.",
+            "readOnly": true
+          },
+          "payment_source": {
+            "$ref": "#/components/schemas/payment_source_response"
+          },
+          "intent": {
+            "$ref": "#/components/schemas/checkout_payment_intent"
+          },
+          "processing_instruction": {
+            "$ref": "#/components/schemas/processing_instruction"
+          },
+          "payer": {
+            "$ref": "#/components/schemas/order-allof1-payer"
+          },
+          "purchase_units": {
+            "$ref": "#/components/schemas/order-allof1-purchase-units"
+          },
+          "status": {
+            "$ref": "#/components/schemas/order-allof1-status"
+          },
+          "links": {
+            "$ref": "#/components/schemas/order-allof1-links"
+          }
+        }
+      },
+      "order-allof1-payer": {
+        "description": "DEPRECATED. The customer is also known as the payer. The Payer object was intended to only be used with the `payment_source.paypal` object. In order to make this design more clear, the details in the `payer` object are now available under `payment_source.paypal`. Please use `payment_source.paypal`.",
+        "deprecated": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payer"
+          }
+        ]
+      },
+      "order-allof1-purchase-units": {
+        "type": "array",
+        "description": "An array of purchase units. Each purchase unit establishes a contract between a customer and merchant. Each purchase unit represents either a full or partial order that the customer intends to purchase from the merchant.",
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/order-allof1-purchase-units-items"
+        }
+      },
+      "order-allof1-purchase-units-items": {
+        "description": "A purchase unit. Establishes a contract between a customer and merchant.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/purchase_unit"
+          }
+        ]
+      },
+      "order-allof1-status": {
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/order_status"
+          }
+        ]
+      },
+      "order-allof1-links": {
+        "type": "array",
+        "description": "An array of request-related HATEOAS links. To complete payer approval, use the `approve` link to redirect the payer. The API caller has 3 hours (default setting, this which can be changed by your account manager to 24/48/72 hours to accommodate your use case) from the time the order is created, to redirect your payer. Once redirected, the API caller has 3 hours for the payer to approve the order and either authorize or capture the order. If you are not using the PayPal JavaScript SDK to initiate PayPal Checkout (in context) ensure that you include `application_context.return_url` is specified or you will get \"We're sorry, Things don't appear to be working at the moment\" after the payer approves the payment.",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/order-allof1-links-items"
+        }
+      },
+      "order-allof1-links-items": {
+        "description": "A request-related [HATEOAS link](/api/rest/responses/#hateoas-links). To complete payer approval, use the `approve` link with the `GET` method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/link_description"
+          }
+        ]
+      },
+      "orders-patch400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-patch400-issues-items"
+        }
+      },
+      "orders-patch400-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/field-not-patchable"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-array-max-items1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-syntax1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value1"
+          },
+          {
+            "$ref": "#/components/schemas/missing-required-parameter1"
+          },
+          {
+            "$ref": "#/components/schemas/amount-not-patchable"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-patch-operation"
+          },
+          {
+            "$ref": "#/components/schemas/malformed-request-json1"
+          }
+        ]
+      },
+      "field-not-patchable": {
+        "title": "FIELD_NOT_PATCHABLE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/field-not-patchable-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/field-not-patchable-description"
+          }
+        }
+      },
+      "invalid-array-max-items1": {
+        "title": "Invalid Array Maximum Items",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-array-max-items1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-array-max-items1-description"
+          }
+        }
+      },
+      "invalid-parameter-syntax1": {
+        "title": "INvalid Parameter Syntax",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax1-description"
+          }
+        }
+      },
+      "invalid-string-length1": {
+        "title": "Invalid String Length",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length1-description"
+          }
+        }
+      },
+      "invalid-parameter-value1": {
+        "title": "Invalid Parameter Value",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value1-description"
+          }
+        }
+      },
+      "missing-required-parameter1": {
+        "title": "Missing Required Parameter",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter1-description"
+          }
+        }
+      },
+      "amount-not-patchable": {
+        "title": "AMOUNT_NOT_PATCHABLE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/amount-not-patchable-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/amount-not-patchable-description"
+          }
+        }
+      },
+      "invalid-patch-operation": {
+        "title": "INVALID_PATCH_OPERATION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-patch-operation-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-patch-operation-description"
+          }
+        }
+      },
+      "malformed-request-json1": {
+        "title": "Malformed request json",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/malformed-request-json1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/malformed-request-json1-description"
+          }
+        }
+      },
+      "orders-patch422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-patch422-issues-items"
+        }
+      },
+      "orders-patch422-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/amount-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/cannot-be-negative1"
+          },
+          {
+            "$ref": "#/components/schemas/cannot-be-zero-or-negative1"
+          },
+          {
+            "$ref": "#/components/schemas/city-required1"
+          },
+          {
+            "$ref": "#/components/schemas/decimal-precision1"
+          },
+          {
+            "$ref": "#/components/schemas/donation-items-not-supported1"
+          },
+          {
+            "$ref": "#/components/schemas/duplicate-reference-id1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-currency-code1"
+          },
+          {
+            "$ref": "#/components/schemas/item-total-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/item-total-required1"
+          },
+          {
+            "$ref": "#/components/schemas/max-value-exceeded1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-json-pointer-format"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter"
+          },
+          {
+            "$ref": "#/components/schemas/not-patchable"
+          },
+          {
+            "$ref": "#/components/schemas/tax-total-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/tax-total-required1"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-intent1"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-patch-parameter-value"
+          },
+          {
+            "$ref": "#/components/schemas/patch-value-required"
+          },
+          {
+            "$ref": "#/components/schemas/patch-path-required"
+          },
+          {
+            "$ref": "#/components/schemas/payee-account-locked-or-closed1"
+          },
+          {
+            "$ref": "#/components/schemas/payee-account-restricted1"
+          },
+          {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired1"
+          },
+          {
+            "$ref": "#/components/schemas/payee-fx-rate-id-currency-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-fx-rate-id1"
+          },
+          {
+            "$ref": "#/components/schemas/platform-fees-not-supported1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-platform-fees-account1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-platform-fees-amount1"
+          },
+          {
+            "$ref": "#/components/schemas/postal-code-required1"
+          },
+          {
+            "$ref": "#/components/schemas/reference-id-not-found"
+          },
+          {
+            "$ref": "#/components/schemas/reference-id-required1"
+          },
+          {
+            "$ref": "#/components/schemas/multi-currency-order1"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-option-not-selected1"
+          },
+          {
+            "$ref": "#/components/schemas/shipping_option_not_supported"
+          },
+          {
+            "$ref": "#/components/schemas/multiple-shipping-option-selected1"
+          },
+          {
+            "$ref": "#/components/schemas/order-already-completed"
+          },
+          {
+            "$ref": "#/components/schemas/preferred-shipping-option-amount-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/amount-change-not-allowed"
+          }
+        ]
+      },
+      "amount-mismatch1": {
+        "title": "Amount Mismatch",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/amount-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/amount-mismatch1-description"
+          }
+        }
+      },
+      "cannot-be-negative1": {
+        "title": "Cannot Be Negative",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cannot-be-negative1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cannot-be-negative1-description"
+          }
+        }
+      },
+      "cannot-be-zero-or-negative1": {
+        "title": "Cannot Be Zero Or Negative",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cannot-be-zero-or-negative1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cannot-be-zero-or-negative1-description"
+          }
+        }
+      },
+      "city-required1": {
+        "title": "City Required",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/city-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/city-required1-description"
+          }
+        }
+      },
+      "decimal-precision1": {
+        "title": "Decimal Precision",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/decimal-precision1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/decimal-precision1-description"
+          }
+        }
+      },
+      "donation-items-not-supported1": {
+        "title": "Donation Items Not Supported",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/donation-items-not-supported1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/donation-items-not-supported1-description"
+          }
+        }
+      },
+      "duplicate-reference-id1": {
+        "title": "Duplicate Reference ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/duplicate-reference-id1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/duplicate-reference-id1-description"
+          }
+        }
+      },
+      "invalid-currency-code1": {
+        "title": "Invalid Currency Code",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-currency-code1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-currency-code1-description"
+          }
+        }
+      },
+      "item-total-mismatch1": {
+        "title": "Item Total Mismatch",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-total-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/item-total-mismatch1-description"
+          }
+        }
+      },
+      "item-total-required1": {
+        "title": "Item Total Required",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-total-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/item-total-required1-description"
+          }
+        }
+      },
+      "max-value-exceeded1": {
+        "title": "Max Value Exceeded",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/max-value-exceeded1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/max-value-exceeded1-description"
+          }
+        }
+      },
+      "invalid-json-pointer-format": {
+        "title": "INVALID_JSON_POINTER_FORMAT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-json-pointer-format-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-json-pointer-format-description"
+          }
+        }
+      },
+      "invalid-parameter": {
+        "title": "INVALID_PARAMETER",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-description"
+          }
+        }
+      },
+      "not-patchable": {
+        "title": "NOT_PATCHABLE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-patchable-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-patchable-description"
+          }
+        }
+      },
+      "tax-total-mismatch1": {
+        "title": "Tax Total Mismatch",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/tax-total-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/tax-total-mismatch1-description"
+          }
+        }
+      },
+      "tax-total-required1": {
+        "title": "Tax Total Required",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/tax-total-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/tax-total-required1-description"
+          }
+        }
+      },
+      "unsupported-intent1": {
+        "title": "Unsupported Intent",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-intent1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-intent1-description"
+          }
+        }
+      },
+      "unsupported-patch-parameter-value": {
+        "title": "UNSUPPORTED_PATCH_PARAMETER_VALUE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-patch-parameter-value-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-patch-parameter-value-description"
+          }
+        }
+      },
+      "patch-value-required": {
+        "title": "PATCH_VALUE_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/patch-value-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/patch-value-required-description"
+          }
+        }
+      },
+      "patch-path-required": {
+        "title": "PATCH_PATH_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/patch-path-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/patch-path-required-description"
+          }
+        }
+      },
+      "payee-account-locked-or-closed1": {
+        "title": "Payee Account Locked Or Closed",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-account-locked-or-closed1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-account-locked-or-closed1-description"
+          }
+        }
+      },
+      "payee-account-restricted1": {
+        "title": "Payee Account Restricted",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-account-restricted1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-account-restricted1-description"
+          }
+        }
+      },
+      "payee-fx-rate-id-expired1": {
+        "title": "Payee FX Rate ID Expired",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired1-description"
+          }
+        }
+      },
+      "payee-fx-rate-id-currency-mismatch1": {
+        "title": "Payee FX Rate ID Currency Mismatch",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-currency-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-currency-mismatch1-description"
+          }
+        }
+      },
+      "invalid-fx-rate-id1": {
+        "title": "Invalid FX Rate ID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-fx-rate-id1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-fx-rate-id1-description"
+          }
+        }
+      },
+      "platform-fees-not-supported1": {
+        "title": "Platform Fees Not Supported",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/platform-fees-not-supported1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/platform-fees-not-supported1-description"
+          }
+        }
+      },
+      "invalid-platform-fees-account1": {
+        "title": "Invalid Platform Fees Account Error",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-platform-fees-account1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-platform-fees-account1-description"
+          }
+        }
+      },
+      "invalid-platform-fees-amount1": {
+        "title": "Invalid Platform Fees Amount",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-platform-fees-amount1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-platform-fees-amount1-description"
+          }
+        }
+      },
+      "postal-code-required1": {
+        "title": "Postal Code Required",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/postal-code-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/postal-code-required1-description"
+          }
+        }
+      },
+      "reference-id-not-found": {
+        "title": "REFERENCE_ID_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/reference-id-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/reference-id-not-found-description"
+          }
+        }
+      },
+      "reference-id-required1": {
+        "title": "Reference ID Required",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/reference-id-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/reference-id-required1-description"
+          }
+        }
+      },
+      "multi-currency-order1": {
+        "title": "Multi-Currency Order",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multi-currency-order1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multi-currency-order1-description"
+          }
+        }
+      },
+      "shipping-option-not-selected1": {
+        "title": "Shipping Option Not Selected",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-option-not-selected1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-option-not-selected1-description"
+          }
+        }
+      },
+      "multiple-shipping-option-selected1": {
+        "title": "Multiple Shipping Option Selected",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/multiple-shipping-option-selected1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/multiple-shipping-option-selected1-description"
+          }
+        }
+      },
+      "order-already-completed": {
+        "title": "ORDER_ALREADY_COMPLETED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-already-completed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-already-completed-description"
+          }
+        }
+      },
+      "preferred-shipping-option-amount-mismatch1": {
+        "title": "Preferred Shipping Option Amount Mismatch",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/preferred-shipping-option-amount-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-option-amount-match-breakdown"
+          }
+        }
+      },
+      "amount-change-not-allowed": {
+        "title": "AMOUNT_CHANGE_NOT_ALLOWED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/amount-change-not-allowed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/amount-change-not-allowed-description"
+          }
+        }
+      },
+      "order-confirm-application-context-locale": {
+        "description": "The BCP 47-formatted locale of pages that the PayPal payment experience shows. PayPal supports a five-character code. For example, `da-DK`, `he-IL`, `id-ID`, `ja-JP`, `no-NO`, `pt-BR`, `ru-RU`, `sv-SE`, `th-TH`, `zh-CN`, `zh-HK`, or `zh-TW`.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/language"
+          }
+        ]
+      },
+      "orders-confirm400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-confirm400-issues-items"
+        }
+      },
+      "orders-confirm400-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-parameter-syntax2"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value2"
+          },
+          {
+            "$ref": "#/components/schemas/missing-required-parameter2"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length2"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-max-length"
+          },
+          {
+            "$ref": "#/components/schemas/malformed-request-json2"
+          }
+        ]
+      },
+      "invalid-parameter-syntax2": {
+        "title": "Invalid Parameter Syntax Error",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax2-description"
+          }
+        }
+      },
+      "invalid-parameter-value2": {
+        "title": "Invalid Parameter Value Error",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value2-description"
+          }
+        }
+      },
+      "missing-required-parameter2": {
+        "title": "Missing Required Parameter Error",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter2-description"
+          }
+        }
+      },
+      "invalid-string-length2": {
+        "title": "Invalid String Length Error",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length2-description"
+          }
+        }
+      },
+      "invalid-string-max-length": {
+        "title": "INVALID_STRING_MAX_LENGTH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-max-length-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-max-length-description"
+          }
+        }
+      },
+      "malformed-request-json2": {
+        "title": "MALFORMED_REQUEST_JSON_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/malformed-request-json2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/malformed-request-json2-description"
+          }
+        }
+      },
+      "orders-confirm422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-confirm422-issues-items"
+        }
+      },
+      "orders-confirm422-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/order-already-captured"
+          },
+          {
+            "$ref": "#/components/schemas/order-already-authorized"
+          },
+          {
+            "$ref": "#/components/schemas/order-cannot-be-confirmed"
+          },
+          {
+            "$ref": "#/components/schemas/missing-previous-reference1"
+          },
+          {
+            "$ref": "#/components/schemas/missing-cryptogram1"
+          },
+          {
+            "$ref": "#/components/schemas/currency-not-supported-for-country"
+          },
+          {
+            "$ref": "#/components/schemas/card-expired1"
+          },
+          {
+            "$ref": "#/components/schemas/card-type-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/currency-not-supported-for-card-type"
+          },
+          {
+            "$ref": "#/components/schemas/only-one-payment-source-allowed"
+          },
+          {
+            "$ref": "#/components/schemas/no-payment-source-provided"
+          },
+          {
+            "$ref": "#/components/schemas/payment-already-approved"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-processing-instruction1"
+          },
+          {
+            "$ref": "#/components/schemas/order-complete-on-payment-approval1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-expiry-date1"
+          },
+          {
+            "$ref": "#/components/schemas/token-expired1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-google-pay-token1"
+          },
+          {
+            "$ref": "#/components/schemas/google-pay-gateway-merchant-id-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/cryptogram-required2"
+          },
+          {
+            "$ref": "#/components/schemas/one-of-parameters-required1"
+          },
+          {
+            "$ref": "#/components/schemas/return-url-required"
+          },
+          {
+            "$ref": "#/components/schemas/cancel-url-required"
+          },
+          {
+            "$ref": "#/components/schemas/country-not-supported-by-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/required-parameter-for-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/required-parameter-for-customer-initiated-payment1"
+          },
+          {
+            "$ref": "#/components/schemas/item-category-not-supported-by-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-info-cannot-be-verified1"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-declined-by-processor1"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-cannot-be-used1"
+          },
+          {
+            "$ref": "#/components/schemas/setup-error-for-bank"
+          },
+          {
+            "$ref": "#/components/schemas/bank-not-supported-for-verification"
+          },
+          {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/one-of-the-parameters-required"
+          },
+          {
+            "$ref": "#/components/schemas/billing-address-invalid1"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-address-invalid1"
+          },
+          {
+            "$ref": "#/components/schemas/order-is-pending-approval"
+          },
+          {
+            "$ref": "#/components/schemas/device-data-not-available"
+          },
+          {
+            "$ref": "#/components/schemas/currency-not-supported-for-bank"
+          },
+          {
+            "$ref": "#/components/schemas/only-one-bank-source-allowed"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-iban"
+          },
+          {
+            "$ref": "#/components/schemas/iban-country-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/payee-country-not-supported-for-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/card-number-required"
+          },
+          {
+            "$ref": "#/components/schemas/card-expiry-required"
+          },
+          {
+            "$ref": "#/components/schemas/incompatible-parameter-value1"
+          },
+          {
+            "$ref": "#/components/schemas/vault-instruction-duplicated1"
+          },
+          {
+            "$ref": "#/components/schemas/vault-instruction-required1"
+          },
+          {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source1"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing1"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-paypal-transaction-id-processing1"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found1"
+          },
+          {
+            "$ref": "#/components/schemas/pnref-not-found1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-security-code-length1"
+          },
+          {
+            "$ref": "#/components/schemas/not-enabled-to-vault-payment-source1"
+          },
+          {
+            "$ref": "#/components/schemas/cryptogram-required3"
+          },
+          {
+            "$ref": "#/components/schemas/emv-data-required1"
+          },
+          {
+            "$ref": "#/components/schemas/alias-declined-by-processor1"
+          },
+          {
+            "$ref": "#/components/schemas/blik-one-click-missing-required-parameter1"
+          }
+        ]
+      },
+      "order-already-captured": {
+        "title": "ORDER_ALREADY_CAPTURED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-already-captured-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-already-captured-description"
+          }
+        }
+      },
+      "order-already-authorized": {
+        "title": "ORDER_ALREADY_AUTHORIZED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-already-authorized-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-already-authorized-description"
+          }
+        }
+      },
+      "order-cannot-be-confirmed": {
+        "title": "ORDER_CANNOT_BE_CONFIRMED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-cannot-be-confirmed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-cannot-be-confirmed-description"
+          }
+        }
+      },
+      "missing-previous-reference1": {
+        "title": "MISSING_PREVIOUS_REFERENCE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-previous-reference1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-previous-reference1-description"
+          }
+        }
+      },
+      "missing-cryptogram1": {
+        "title": "MISSING_CRYPTOGRAM_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-cryptogram1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-cryptogram1-description"
+          }
+        }
+      },
+      "currency-not-supported-for-country": {
+        "title": "CURRENCY_NOT_SUPPORTED_FOR_COUNTRY",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/currency-not-supported-for-country-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/currency-not-supported-for-country-description"
+          }
+        }
+      },
+      "card-expired1": {
+        "title": "CARD_EXPIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-expired1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-expired1-description"
+          }
+        }
+      },
+      "card-type-not-supported": {
+        "title": "CARD_TYPE_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-type-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-type-not-supported-description"
+          }
+        }
+      },
+      "currency-not-supported-for-card-type": {
+        "title": "CURRENCY_NOT_SUPPORTED_FOR_CARD_TYPE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/currency-not-supported-for-card-type-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/currency-not-supported-for-card-type-description"
+          }
+        }
+      },
+      "only-one-payment-source-allowed": {
+        "title": "ONLY_ONE_PAYMENT_SOURCE_ALLOWED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/only-one-payment-source-allowed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/only-one-payment-source-allowed-description"
+          }
+        }
+      },
+      "no-payment-source-provided": {
+        "title": "NO_PAYMENT_SOURCE_PROVIDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/no-payment-source-provided-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/no-payment-source-provided-description"
+          }
+        }
+      },
+      "payment-already-approved": {
+        "title": "PAYMENT_ALREADY_APPROVED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-already-approved-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-already-approved-description"
+          }
+        }
+      },
+      "unsupported-processing-instruction1": {
+        "title": "UNSUPPORTED_PROCESSING_INSTRUCTION_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-processing-instruction1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-processing-instruction1-description"
+          }
+        }
+      },
+      "order-complete-on-payment-approval1": {
+        "title": "ORDER_COMPLETE_ON_PAYMENT_APPROVAL_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-complete-on-payment-approval1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-complete-on-payment-approval1-description"
+          }
+        }
+      },
+      "invalid-expiry-date1": {
+        "title": "INVALID_EXPIRY_DATE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-expiry-date1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-expiry-date1-description"
+          }
+        }
+      },
+      "token-expired1": {
+        "title": "TOKEN_EXPIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/token-expired1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/token-expired1-description"
+          }
+        }
+      },
+      "invalid-google-pay-token1": {
+        "title": "INVALID_GOOGLE_PAY_TOKEN_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-google-pay-token1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-google-pay-token1-description"
+          }
+        }
+      },
+      "google-pay-gateway-merchant-id-mismatch1": {
+        "title": "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/google-pay-gateway-merchant-id-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-google-pay-merchant-id-mismatch"
+          }
+        }
+      },
+      "cryptogram-required2": {
+        "title": "CRYPTOGRAM_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cryptogram-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cryptogram-required2-description"
+          }
+        }
+      },
+      "one-of-parameters-required1": {
+        "title": "ONE_OF_PARAMETERS_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/one-of-parameters-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/one-of-parameters-required1-description"
+          }
+        }
+      },
+      "return-url-required": {
+        "title": "RETURN_URL_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/return-url-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/return-url-required-description"
+          }
+        }
+      },
+      "cancel-url-required": {
+        "title": "CANCEL_URL_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cancel-url-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cancel-url-required-description"
+          }
+        }
+      },
+      "country-not-supported-by-payment-source": {
+        "title": "COUNTRY_NOT_SUPPORTED_BY_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/country-not-supported-by-payment-source-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-country-code-payment-source"
+          }
+        }
+      },
+      "required-parameter-for-payment-source": {
+        "title": "REQUIRED_PARAMETER_FOR_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/required-parameter-for-payment-source-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/required-parameter-for-payment-source-description"
+          }
+        }
+      },
+      "required-parameter-for-customer-initiated-payment1": {
+        "title": "MISSING_PAYMENT_PARAM_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/customer-initiated-payment-required-param"
+          },
+          "description": {
+            "$ref": "#/components/schemas/req-param-cust-present-initiator"
+          }
+        }
+      },
+      "item-category-not-supported-by-payment-source": {
+        "title": "ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-category-not-supported-payment-source"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-does-not-support-item-category"
+          }
+        }
+      },
+      "payment-source-info-cannot-be-verified1": {
+        "title": "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-info-cannot-be-verified1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unverified-payment-source-and-address-combination"
+          }
+        }
+      },
+      "payment-source-declined-by-processor1": {
+        "title": "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-declined-by-processor1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-declined-by-processor1-description"
+          }
+        }
+      },
+      "payment-source-cannot-be-used1": {
+        "title": "PAYMENT_SOURCE_CANNOT_BE_USED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-cannot-be-used1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-cannot-be-used1-description"
+          }
+        }
+      },
+      "setup-error-for-bank": {
+        "title": "SETUP_ERROR_FOR_BANK",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/setup-error-for-bank-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/setup-error-for-bank-description"
+          }
+        }
+      },
+      "bank-not-supported-for-verification": {
+        "title": "BANK_NOT_SUPPORTED_FOR_VERIFICATION",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/bank-not-supported-for-verification-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/bank-not-supported-for-verification-description"
+          }
+        }
+      },
+      "apple-pay-amount-mismatch1": {
+        "title": "APPLE_PAY_AMOUNT_MISMATCH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch1-description"
+          }
+        }
+      },
+      "one-of-the-parameters-required": {
+        "title": "ONE_OF_THE_PARAMETERS_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/one-of-the-parameters-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/one-of-the-parameters-required-description"
+          }
+        }
+      },
+      "billing-address-invalid1": {
+        "title": "BILLING_ADDRESS_INVALID_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-address-invalid1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-address-invalid1-description"
+          }
+        }
+      },
+      "shipping-address-invalid1": {
+        "title": "SHIPPING_ADDRESS_INVALID_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-address-invalid1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-address-invalid1-description"
+          }
+        }
+      },
+      "order-is-pending-approval": {
+        "title": "ORDER_IS_PENDING_APPROVAL",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-is-pending-approval-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-is-pending-approval-description"
+          }
+        }
+      },
+      "device-data-not-available": {
+        "title": "DEVICE_DATA_NOT_AVAILABLE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/device-data-not-available-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/device-data-not-available-description"
+          }
+        }
+      },
+      "currency-not-supported-for-bank": {
+        "title": "CURRENCY_NOT_SUPPORTED_FOR_BANK",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/currency-not-supported-for-bank-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/currency-not-supported-for-bank-description"
+          }
+        }
+      },
+      "only-one-bank-source-allowed": {
+        "title": "ONLY_ONE_BANK_SOURCE_ALLOWED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/only-one-bank-source-allowed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/only-one-bank-source-allowed-description"
+          }
+        }
+      },
+      "invalid-iban": {
+        "title": "INVALID_IBAN",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-iban-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-iban-description"
+          }
+        }
+      },
+      "iban-country-not-supported": {
+        "title": "IBAN_COUNTRY_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/iban-country-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/iban-country-not-supported-description"
+          }
+        }
+      },
+      "payee-country-not-supported-for-payment-source": {
+        "title": "PAYEE_COUNTRY_NOT_SUPPORTED_FOR_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-country-not-supported-payment-source"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-country-code-not-supported-payment-source"
+          }
+        }
+      },
+      "card-number-required": {
+        "title": "CARD_NUMBER_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-number-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-number-required-description"
+          }
+        }
+      },
+      "card-expiry-required": {
+        "title": "CARD_EXPIRY_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-expiry-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-expiry-required-description"
+          }
+        }
+      },
+      "incompatible-parameter-value1": {
+        "title": "INCOMPATIBLE_PARAMETER_VALUE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/incompatible-parameter-value1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/incompatible-parameter-value1-description"
+          }
+        }
+      },
+      "vault-instruction-duplicated1": {
+        "title": "VAULT_INSTRUCTION_DUPLICATED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/vault-instruction-duplicated1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/vault-instruction-duplicated1-description"
+          }
+        }
+      },
+      "vault-instruction-required1": {
+        "title": "VAULT_INSTRUCTION_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/vault-instruction-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/vault-instruction-required1-description"
+          }
+        }
+      },
+      "mismatched-vault-id-to-payment-source1": {
+        "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source1-description"
+          }
+        }
+      },
+      "not-eligible-for-pnref-processing1": {
+        "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing1-description"
+          }
+        }
+      },
+      "not-eligible-for-paypal-transaction-id-processing1": {
+        "title": "PAYPAL_ID_PROCESSING_INELIGIBILITY_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-paypal-transaction-id-processing"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-processing-permission-error"
+          }
+        }
+      },
+      "paypal-transaction-id-not-found1": {
+        "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found1-description"
+          }
+        }
+      },
+      "pnref-not-found1": {
+        "title": "PNREF_NOT_FOUND_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/pnref-not-found1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/pnref-not-found1-description"
+          }
+        }
+      },
+      "invalid-security-code-length1": {
+        "title": "INVALID_SECURITY_CODE_LENGTH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-security-code-length1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-security-code-length1-description"
+          }
+        }
+      },
+      "not-enabled-to-vault-payment-source1": {
+        "title": "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-enabled-to-vault-payment-source1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-enabled-to-vault-payment-source1-description"
+          }
+        }
+      },
+      "cryptogram-required3": {
+        "title": "CRYPTOGRAM_IS_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cryptogram-required3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cryptogram-required3-description"
+          }
+        }
+      },
+      "emv-data-required1": {
+        "title": "EMV_DATA_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/emv-data-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/emv-data-required1-description"
+          }
+        }
+      },
+      "alias-declined-by-processor1": {
+        "title": "ALIAS_DECLINED_BY_PROCESSOR_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/alias-declined-by-processor1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/alias-declined-by-processor1-description"
+          }
+        }
+      },
+      "blik-one-click-missing-required-parameter1": {
+        "title": "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/blik-one-click-missing-required-parameter1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/blik-one-click-first-transaction-params"
+          }
+        }
+      },
+      "order-authorize-request-payment-source": {
+        "description": "The source of payment for the order, which can be a token or a card. Use this object only if you have not redirected the user after order creation to approve the payment. In such cases, the user-selected payment method in the PayPal flow is implicitly used.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/payment_source"
+          }
+        ]
+      },
+      "order-authorize-response-allof1": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the order.",
+            "readOnly": true
+          },
+          "payment_source": {
+            "$ref": "#/components/schemas/payment_source_response"
+          },
+          "intent": {
+            "$ref": "#/components/schemas/checkout_payment_intent"
+          },
+          "processing_instruction": {
+            "$ref": "#/components/schemas/processing_instruction"
+          },
+          "payer": {
+            "$ref": "#/components/schemas/payer"
+          },
+          "purchase_units": {
+            "$ref": "#/components/schemas/order-authorize-response-allof1-purchase-units"
+          },
+          "status": {
+            "$ref": "#/components/schemas/order-authorize-response-allof1-status"
+          },
+          "links": {
+            "$ref": "#/components/schemas/order-authorize-response-allof1-links"
+          }
+        }
+      },
+      "order-authorize-response-allof1-purchase-units": {
+        "type": "array",
+        "description": "An array of purchase units. Each purchase unit establishes a contract between a customer and merchant. Each purchase unit represents either a full or partial order that the customer intends to purchase from the merchant.",
+        "minItems": 1,
+        "maxItems": 10,
+        "items": {
+          "$ref": "#/components/schemas/purchase-unit-contract"
+        }
+      },
+      "purchase-unit-contract": {
+        "description": "A purchase unit. Establishes a contract between a customer and merchant.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/purchase_unit"
+          }
+        ]
+      },
+      "order-authorize-response-allof1-status": {
+        "readOnly": true,
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/order_status"
+          }
+        ]
+      },
+      "order-authorize-response-allof1-links": {
+        "type": "array",
+        "description": "An array of request-related HATEOAS links. To complete payer approval, use the `approve` link to redirect the payer. The API caller has 3 hours (default setting, this which can be changed by your account manager to 24/48/72 hours to accommodate your use case) from the time the order is created, to redirect your payer. Once redirected, the API caller has 3 hours for the payer to approve the order and either authorize or capture the order. If you are not using the PayPal JavaScript SDK to initiate PayPal Checkout (in context) ensure that you include `application_context.return_url` is specified or you will get \"We're sorry, Things don't appear to be working at the moment\" after the payer approves the payment.",
+        "readOnly": true,
+        "items": {
+          "$ref": "#/components/schemas/order-authorize-response-allof1-links-items"
+        }
+      },
+      "order-authorize-response-allof1-links-items": {
+        "description": "A request-related [HATEOAS link](/api/rest/responses/#hateoas-links). To complete payer approval, use the `approve` link with the `GET` method.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/link_description"
+          }
+        ]
+      },
+      "orders-authorize400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-authorize400-issues-items"
+        }
+      },
+      "orders-authorize400-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-country-code1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value3"
+          },
+          {
+            "$ref": "#/components/schemas/missing-required-parameter3"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length3"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-syntax3"
+          },
+          {
+            "$ref": "#/components/schemas/malformed-request-json3"
+          }
+        ]
+      },
+      "invalid-country-code1": {
+        "title": "INVALID_COUNTRY_CODE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-country-code1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-country-code1-description"
+          }
+        }
+      },
+      "invalid-parameter-value3": {
+        "title": "INVALID_PARAMETER_VALUE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value3-description"
+          }
+        }
+      },
+      "missing-required-parameter3": {
+        "title": "MISSING_REQUIRED_PARAMETER_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter3-description"
+          }
+        }
+      },
+      "invalid-string-length3": {
+        "title": "INVALID_STRING_LENGTH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length3-description"
+          }
+        }
+      },
+      "invalid-parameter-syntax3": {
+        "title": "INVALID_PARAMETER_SYNTAX_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax3-description"
+          }
+        }
+      },
+      "malformed-request-json3": {
+        "title": "MALFORMED_REQUEST_JSON_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/malformed-request-json3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/malformed-request-json3-description"
+          }
+        }
+      },
+      "orders-authorize403-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-authorize403-issues-items"
+        }
+      },
+      "orders-authorize403-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/not-eligible-for-token-processing"
+          },
+          {
+            "$ref": "#/components/schemas/permission-denied1"
+          },
+          {
+            "$ref": "#/components/schemas/permission-denied-for-donation-items"
+          }
+        ]
+      },
+      "not-eligible-for-token-processing": {
+        "title": "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-token-processing-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-eligible-for-token-processing-description"
+          }
+        }
+      },
+      "permission-denied1": {
+        "title": "PERMISSION_DENIED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied1-description"
+          }
+        }
+      },
+      "permission-denied-for-donation-items": {
+        "title": "PERMISSION_DENIED_FOR_DONATION_ITEMS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied-for-donation-items-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied-for-donation-items-description"
+          }
+        }
+      },
+      "orders-authorize422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-authorize422-issues-items"
+        }
+      },
+      "orders-authorize422-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/action-does-not-match-intent"
+          },
+          {
+            "$ref": "#/components/schemas/agreement-already-cancelled1"
+          },
+          {
+            "$ref": "#/components/schemas/billing-agreement-not-found1"
+          },
+          {
+            "$ref": "#/components/schemas/missing-previous-reference2"
+          },
+          {
+            "$ref": "#/components/schemas/missing-cryptogram2"
+          },
+          {
+            "$ref": "#/components/schemas/card-brand-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/declined-due-to-related-txn"
+          },
+          {
+            "$ref": "#/components/schemas/domestic-transaction-required1"
+          },
+          {
+            "$ref": "#/components/schemas/duplicate-invoice-id1"
+          },
+          {
+            "$ref": "#/components/schemas/order-not-approved"
+          },
+          {
+            "$ref": "#/components/schemas/max-number-of-payment-attempts-exceeded1"
+          },
+          {
+            "$ref": "#/components/schemas/payee-blocked-transaction1"
+          },
+          {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired2"
+          },
+          {
+            "$ref": "#/components/schemas/unsupported-intent-for-payment-source"
+          },
+          {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed1"
+          },
+          {
+            "$ref": "#/components/schemas/payer-account-restricted1"
+          },
+          {
+            "$ref": "#/components/schemas/payer-cannot-pay1"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-transaction-id-expired"
+          },
+          {
+            "$ref": "#/components/schemas/pnref-expired"
+          },
+          {
+            "$ref": "#/components/schemas/referenced-card-expired"
+          },
+          {
+            "$ref": "#/components/schemas/token-expired2"
+          },
+          {
+            "$ref": "#/components/schemas/token-id-not-found"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-limit-exceeded1"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded1"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-refused1"
+          },
+          {
+            "$ref": "#/components/schemas/order-already-authorized1"
+          },
+          {
+            "$ref": "#/components/schemas/auth-capture-not-enabled1"
+          },
+          {
+            "$ref": "#/components/schemas/amount-cannot-be-specified"
+          },
+          {
+            "$ref": "#/components/schemas/authorization-amount-exceeded"
+          },
+          {
+            "$ref": "#/components/schemas/authorization-currency-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/max-authorization-count-exceeded"
+          },
+          {
+            "$ref": "#/components/schemas/order-completed-or-voided"
+          },
+          {
+            "$ref": "#/components/schemas/order-expired"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-pickup-address"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-address-invalid2"
+          },
+          {
+            "$ref": "#/components/schemas/payment-type-not-supported-for-intent"
+          },
+          {
+            "$ref": "#/components/schemas/billing-agreement-id-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/preferred-payment-source-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/incompatible-parameter-value2"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference1"
+          },
+          {
+            "$ref": "#/components/schemas/previous-transaction-reference-has-chargeback1"
+          },
+          {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided1"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code1"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-authentication-results1"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-multiple-purchase-units1"
+          },
+          {
+            "$ref": "#/components/schemas/return-url-required1"
+          },
+          {
+            "$ref": "#/components/schemas/cancel-url-required1"
+          },
+          {
+            "$ref": "#/components/schemas/payer-action-required"
+          },
+          {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch2"
+          },
+          {
+            "$ref": "#/components/schemas/card-number-required1"
+          },
+          {
+            "$ref": "#/components/schemas/card-expiry-required1"
+          },
+          {
+            "$ref": "#/components/schemas/vault-instruction-required2"
+          },
+          {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source2"
+          },
+          {
+            "$ref": "#/components/schemas/order-cannot-be-saved"
+          },
+          {
+            "$ref": "#/components/schemas/save-order-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing2"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-paypal-transaction-id-processing2"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found2"
+          },
+          {
+            "$ref": "#/components/schemas/pnref-not-found2"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-security-code-length2"
+          },
+          {
+            "$ref": "#/components/schemas/required-parameter-for-customer-initiated-payment2"
+          }
+        ]
+      },
+      "action-does-not-match-intent": {
+        "title": "ACTION_DOES_NOT_MATCH_INTENT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/action-does-not-match-intent-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/action-does-not-match-intent-description"
+          }
+        }
+      },
+      "agreement-already-cancelled1": {
+        "title": "AGREEMENT_ALREADY_CANCELLED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/agreement-already-cancelled1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/agreement-already-cancelled1-description"
+          }
+        }
+      },
+      "billing-agreement-not-found1": {
+        "title": "BILLING_AGREEMENT_NOT_FOUND_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-agreement-not-found1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-agreement-not-found1-description"
+          }
+        }
+      },
+      "missing-previous-reference2": {
+        "title": "MISSING_PREVIOUS_REFERENCE_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-previous-reference2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-previous-reference2-description"
+          }
+        }
+      },
+      "missing-cryptogram2": {
+        "title": "MISSING_CRYPTOGRAM_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-cryptogram2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-cryptogram2-description"
+          }
+        }
+      },
+      "card-brand-not-supported": {
+        "title": "CARD_BRAND_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-brand-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-brand-not-supported-description"
+          }
+        }
+      },
+      "declined-due-to-related-txn": {
+        "title": "DECLINED_DUE_TO_RELATED_TXN",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/declined-due-to-related-txn-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/declined-due-to-related-txn-description"
+          }
+        }
+      },
+      "domestic-transaction-required1": {
+        "title": "DOMESTIC_TRANSACTION_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/domestic-transaction-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/domestic-transaction-required1-description"
+          }
+        }
+      },
+      "duplicate-invoice-id1": {
+        "title": "DUPLICATE_INVOICE_ID_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/duplicate-invoice-id1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/duplicate-invoice-id1-description"
+          }
+        }
+      },
+      "order-not-approved": {
+        "title": "ORDER_NOT_APPROVED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-not-approved-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-not-approved-description"
+          }
+        }
+      },
+      "max-number-of-payment-attempts-exceeded1": {
+        "title": "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/max-number-of-payment-attempts-exceeded1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/exceeded-max-payment-attempts-error"
+          }
+        }
+      },
+      "payee-blocked-transaction1": {
+        "title": "PAYEE_BLOCKED_TRANSACTION_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-blocked-transaction1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-blocked-transaction1-description"
+          }
+        }
+      },
+      "payee-fx-rate-id-expired2": {
+        "title": "PAYEE_FX_RATE_ID_EXPIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired2-description"
+          }
+        }
+      },
+      "unsupported-intent-for-payment-source": {
+        "title": "UNSUPPORTED_INTENT_FOR_PAYMENT_SOURCE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/unsupported-intent-for-payment-source-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/unsupported-intent-for-payment-source-description"
+          }
+        }
+      },
+      "payer-account-locked-or-closed1": {
+        "title": "PAYER_ACCOUNT_LOCKED_OR_CLOSED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed1-description"
+          }
+        }
+      },
+      "payer-account-restricted1": {
+        "title": "PAYER_ACCOUNT_RESTRICTED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-account-restricted1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-account-restricted1-description"
+          }
+        }
+      },
+      "payer-cannot-pay1": {
+        "title": "PAYER_CANNOT_PAY_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-cannot-pay1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-cannot-pay1-description"
+          }
+        }
+      },
+      "paypal-transaction-id-expired": {
+        "title": "PAYPAL_TRANSACTION_ID_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-transaction-id-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-expired-description"
+          }
+        }
+      },
+      "pnref-expired": {
+        "title": "PNREF_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/pnref-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/pnref-expired-description"
+          }
+        }
+      },
+      "referenced-card-expired": {
+        "title": "REFERENCED_CARD_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/referenced-card-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/referenced-card-expired-description"
+          }
+        }
+      },
+      "token-expired2": {
+        "title": "TOKEN_EXPIRED_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/token-expired2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/token-expired2-description"
+          }
+        }
+      },
+      "token-id-not-found": {
+        "title": "TOKEN_ID_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/token-id-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/token-id-not-found-description"
+          }
+        }
+      },
+      "transaction-limit-exceeded1": {
+        "title": "TRANSACTION_LIMIT_EXCEEDED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-limit-exceeded1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-limit-exceeded1-description"
+          }
+        }
+      },
+      "transaction-receiving-limit-exceeded1": {
+        "title": "TRANSACTION_RECEIVING_LIMIT_EXCEEDED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded1-description"
+          }
+        }
+      },
+      "transaction-refused1": {
+        "title": "TRANSACTION_REFUSED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-refused1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-refused1-description"
+          }
+        }
+      },
+      "order-already-authorized1": {
+        "title": "ORDER_ALREADY_AUTHORIZED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-already-authorized1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-already-authorized1-description"
+          }
+        }
+      },
+      "auth-capture-not-enabled1": {
+        "title": "AUTH_CAPTURE_NOT_ENABLED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/auth-capture-not-enabled1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/auth-capture-not-enabled1-description"
+          }
+        }
+      },
+      "amount-cannot-be-specified": {
+        "title": "AMOUNT_CANNOT_BE_SPECIFIED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/amount-cannot-be-specified-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/amount-cannot-be-specified-description"
+          }
+        }
+      },
+      "authorization-amount-exceeded": {
+        "title": "AUTHORIZATION_AMOUNT_EXCEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/authorization-amount-exceeded-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/authorization-amount-exceeded-description"
+          }
+        }
+      },
+      "authorization-currency-mismatch": {
+        "title": "AUTHORIZATION_CURRENCY_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/authorization-currency-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/authorization-currency-mismatch-description"
+          }
+        }
+      },
+      "max-authorization-count-exceeded": {
+        "title": "MAX_AUTHORIZATION_COUNT_EXCEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/max-authorization-count-exceeded-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/max-authorization-count-exceeded-description"
+          }
+        }
+      },
+      "order-completed-or-voided": {
+        "title": "ORDER_COMPLETED_OR_VOIDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-completed-or-voided-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-completed-or-voided-description"
+          }
+        }
+      },
+      "order-expired": {
+        "title": "ORDER_EXPIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-expired-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-expired-description"
+          }
+        }
+      },
+      "invalid-pickup-address": {
+        "title": "INVALID_PICKUP_ADDRESS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-pickup-address-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-pickup-address-description"
+          }
+        }
+      },
+      "shipping-address-invalid2": {
+        "title": "SHIPPING_ADDRESS_INVALID_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-address-invalid2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-address-invalid2-description"
+          }
+        }
+      },
+      "payment-type-not-supported-for-intent": {
+        "title": "PAYMENT_TYPE_NOT_SUPPORTED_FOR_INTENT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-type-not-supported-for-intent-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-type-not-supported-for-intent-description"
+          }
+        }
+      },
+      "billing-agreement-id-mismatch": {
+        "title": "BILLING_AGREEMENT_ID_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-agreement-id-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-agreement-id-mismatch-description"
+          }
+        }
+      },
+      "preferred-payment-source-mismatch": {
+        "title": "PREFERRED_PAYMENT_SOURCE_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/preferred-payment-source-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/preferred-payment-source-mismatch-description"
+          }
+        }
+      },
+      "incompatible-parameter-value2": {
+        "title": "INCOMPATIBLE_PARAMETER_VALUE_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/incompatible-parameter-value2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/incompatible-parameter-value2-description"
+          }
+        }
+      },
+      "invalid-previous-transaction-reference1": {
+        "title": "INVALID_PREVIOUS_TRANSACTION_REFERENCE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference-error"
+          }
+        }
+      },
+      "previous-transaction-reference-has-chargeback1": {
+        "title": "CHARGEBACK_ON_PREVIOUS_TRANSACTION_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/previous-transaction-reference-chargeback-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/capture-with-chargeback-not-usable-desc"
+          }
+        }
+      },
+      "previous-transaction-reference-voided1": {
+        "title": "PREVIOUS_TRANSACTION_REFERENCE_VOIDED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided1-description"
+          }
+        }
+      },
+      "payment-source-mismatch1": {
+        "title": "PAYMENT_SOURCE_MISMATCH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-mismatch1-description"
+          }
+        }
+      },
+      "merchant-initiated-with-security-code1": {
+        "title": "MERCHANT_INITIATED_WITH_SECURITY_CODE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code1-description"
+          }
+        }
+      },
+      "merchant-initiated-with-authentication-results1": {
+        "title": "MERCHANT_AUTH_RESULTS_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-auth-with-results"
+          },
+          "description": {
+            "$ref": "#/components/schemas/err-merch-init-auth-results-3ds-invalid"
+          }
+        }
+      },
+      "merchant-initiated-with-multiple-purchase-units1": {
+        "title": "MULTI_PURCHASE_UNITS_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-multiple-purchase-units-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/err-merch-init-multi-units-not-supported"
+          }
+        }
+      },
+      "return-url-required1": {
+        "title": "RETURN_URL_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/return-url-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/return-url-required1-description"
+          }
+        }
+      },
+      "cancel-url-required1": {
+        "title": "CANCEL_URL_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cancel-url-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cancel-url-required1-description"
+          }
+        }
+      },
+      "payer-action-required": {
+        "title": "PAYER_ACTION_REQUIRED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-action-required-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-action-required-description"
+          }
+        }
+      },
+      "apple-pay-amount-mismatch2": {
+        "title": "APPLE_PAY_AMOUNT_MISMATCH_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch2-description"
+          }
+        }
+      },
+      "card-number-required1": {
+        "title": "CARD_NUMBER_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-number-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-number-required1-description"
+          }
+        }
+      },
+      "card-expiry-required1": {
+        "title": "CARD_EXPIRY_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-expiry-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-expiry-required1-description"
+          }
+        }
+      },
+      "vault-instruction-required2": {
+        "title": "VAULT_INSTRUCTION_REQUIRED_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/vault-instruction-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/vault-instruction-required2-description"
+          }
+        }
+      },
+      "mismatched-vault-id-to-payment-source2": {
+        "title": "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source2-description"
+          }
+        }
+      },
+      "order-cannot-be-saved": {
+        "title": "ORDER_CANNOT_BE_SAVED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-cannot-be-saved-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-cannot-be-saved-description"
+          }
+        }
+      },
+      "save-order-not-supported": {
+        "title": "SAVE_ORDER_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/save-order-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/save-order-not-supported-description"
+          }
+        }
+      },
+      "not-eligible-for-pnref-processing2": {
+        "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing2-description"
+          }
+        }
+      },
+      "not-eligible-for-paypal-transaction-id-processing2": {
+        "title": "PAYPAL_ID_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-paypal-tx-id-processing"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-tx-id-processing-permission-needed"
+          }
+        }
+      },
+      "paypal-transaction-id-not-found2": {
+        "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found2-description"
+          }
+        }
+      },
+      "pnref-not-found2": {
+        "title": "PNREF_NOT_FOUND_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/pnref-not-found2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/pnref-not-found2-description"
+          }
+        }
+      },
+      "invalid-security-code-length2": {
+        "title": "INVALID_SECURITY_CODE_LENGTH_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-security-code-length2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-security-code-length2-description"
+          }
+        }
+      },
+      "required-parameter-for-customer-initiated-payment2": {
+        "title": "MISSING_PAYMENT_PARAMETER",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/required-param-for-cust-initiated-payment"
+          },
+          "description": {
+            "$ref": "#/components/schemas/req-param-cust-present-initiator-merch-desc"
+          }
+        }
+      },
+      "orders-capture400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-capture400-issues-items"
+        }
+      },
+      "orders-capture400-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value4"
+          },
+          {
+            "$ref": "#/components/schemas/missing-required-parameter4"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length4"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-syntax4"
+          },
+          {
+            "$ref": "#/components/schemas/malformed-request-json4"
+          }
+        ]
+      },
+      "invalid-parameter-value4": {
+        "title": "INVALID_PARAMETER_VALUE_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value4-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value4-description"
+          }
+        }
+      },
+      "missing-required-parameter4": {
+        "title": "MISSING_REQUIRED_PARAMETER_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter4-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter4-description"
+          }
+        }
+      },
+      "invalid-string-length4": {
+        "title": "INVALID_STRING_LENGTH_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length4-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length4-description"
+          }
+        }
+      },
+      "invalid-parameter-syntax4": {
+        "title": "INVALID_PARAMETER_SYNTAX_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax4-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax4-description"
+          }
+        }
+      },
+      "malformed-request-json4": {
+        "title": "MALFORMED_REQUEST_JSON_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/malformed-request-json4-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/malformed-request-json4-description"
+          }
+        }
+      },
+      "orders-capture403-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-capture403-issues-items"
+        }
+      },
+      "orders-capture403-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/consent-needed"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-token-processing1"
+          },
+          {
+            "$ref": "#/components/schemas/permission-denied2"
+          },
+          {
+            "$ref": "#/components/schemas/permission-denied-for-donation-items1"
+          }
+        ]
+      },
+      "consent-needed": {
+        "title": "CONSENT_NEEDED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/consent-needed-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/consent-needed-description"
+          }
+        }
+      },
+      "not-eligible-for-token-processing1": {
+        "title": "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-token-processing1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-eligible-for-token-processing1-description"
+          }
+        }
+      },
+      "permission-denied2": {
+        "title": "PERMISSION_DENIED_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied2-description"
+          }
+        }
+      },
+      "permission-denied-for-donation-items1": {
+        "title": "PERMISSION_DENIED_FOR_DONATION_ITEMS_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied-for-donation-items1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied-for-donation-items1-description"
+          }
+        }
+      },
+      "orders-capture422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-capture422-issues-items"
+        }
+      },
+      "orders-capture422-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/agreement-already-cancelled2"
+          },
+          {
+            "$ref": "#/components/schemas/billing-agreement-not-found2"
+          },
+          {
+            "$ref": "#/components/schemas/declined-due-to-related-txn1"
+          },
+          {
+            "$ref": "#/components/schemas/missing-previous-reference3"
+          },
+          {
+            "$ref": "#/components/schemas/missing-cryptogram3"
+          },
+          {
+            "$ref": "#/components/schemas/card-brand-not-supported1"
+          },
+          {
+            "$ref": "#/components/schemas/compliance-violation1"
+          },
+          {
+            "$ref": "#/components/schemas/domestic-transaction-required2"
+          },
+          {
+            "$ref": "#/components/schemas/duplicate-invoice-id2"
+          },
+          {
+            "$ref": "#/components/schemas/instrument-declined1"
+          },
+          {
+            "$ref": "#/components/schemas/order-not-approved1"
+          },
+          {
+            "$ref": "#/components/schemas/max-number-of-payment-attempts-exceeded2"
+          },
+          {
+            "$ref": "#/components/schemas/payee-blocked-transaction2"
+          },
+          {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired3"
+          },
+          {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed2"
+          },
+          {
+            "$ref": "#/components/schemas/payer-account-restricted2"
+          },
+          {
+            "$ref": "#/components/schemas/payer-cannot-pay2"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-transaction-id-expired1"
+          },
+          {
+            "$ref": "#/components/schemas/pnref-expired1"
+          },
+          {
+            "$ref": "#/components/schemas/referenced-card-expired1"
+          },
+          {
+            "$ref": "#/components/schemas/token-id-not-found1"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-limit-exceeded2"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded2"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-refused2"
+          },
+          {
+            "$ref": "#/components/schemas/redirect-payer-for-alternate-funding"
+          },
+          {
+            "$ref": "#/components/schemas/order-already-captured1"
+          },
+          {
+            "$ref": "#/components/schemas/transaction-blocked-by-payee1"
+          },
+          {
+            "$ref": "#/components/schemas/auth-capture-not-enabled2"
+          },
+          {
+            "$ref": "#/components/schemas/not-enabled-for-bank-processing"
+          },
+          {
+            "$ref": "#/components/schemas/not_enabled_for_card_processing"
+          },
+          {
+            "$ref": "#/components/schemas/payee-not-enabled-for-bank-processing"
+          },
+          {
+            "$ref": "#/components/schemas/payee-not-enabled-for-card-processing"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-pickup-address1"
+          },
+          {
+            "$ref": "#/components/schemas/shipping-address-invalid3"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-not-supported"
+          },
+          {
+            "$ref": "#/components/schemas/order-completion-in-progress"
+          },
+          {
+            "$ref": "#/components/schemas/billing-agreement-id-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/preferred-payment-source-mismatch1"
+          },
+          {
+            "$ref": "#/components/schemas/incompatible-parameter-value3"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference2"
+          },
+          {
+            "$ref": "#/components/schemas/previous-transaction-reference-has-chargeback2"
+          },
+          {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided2"
+          },
+          {
+            "$ref": "#/components/schemas/payment-source-mismatch2"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code2"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-authentication-results2"
+          },
+          {
+            "$ref": "#/components/schemas/merchant-initiated-with-multiple-purchase-units2"
+          },
+          {
+            "$ref": "#/components/schemas/return-url-required2"
+          },
+          {
+            "$ref": "#/components/schemas/cancel-url-required2"
+          },
+          {
+            "$ref": "#/components/schemas/setup-error-for-bank1"
+          },
+          {
+            "$ref": "#/components/schemas/bank-not-supported-for-verification1"
+          },
+          {
+            "$ref": "#/components/schemas/payer-action-required1"
+          },
+          {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch3"
+          },
+          {
+            "$ref": "#/components/schemas/currency-not-supported-for-bank1"
+          },
+          {
+            "$ref": "#/components/schemas/only-one-bank-source-allowed1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-iban1"
+          },
+          {
+            "$ref": "#/components/schemas/iban-country-not-supported1"
+          },
+          {
+            "$ref": "#/components/schemas/card-number-required2"
+          },
+          {
+            "$ref": "#/components/schemas/card-expiry-required2"
+          },
+          {
+            "$ref": "#/components/schemas/vault-instruction-required3"
+          },
+          {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source3"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing3"
+          },
+          {
+            "$ref": "#/components/schemas/not-eligible-for-paypal-transaction-id-processing3"
+          },
+          {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found3"
+          },
+          {
+            "$ref": "#/components/schemas/pnref-not-found3"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-security-code-length3"
+          },
+          {
+            "$ref": "#/components/schemas/platform-fee-payee-cannot-be-same-as-payer"
+          },
+          {
+            "$ref": "#/components/schemas/required-parameter-for-customer-initiated-payment3"
+          },
+          {
+            "$ref": "#/components/schemas/identifier-not-found"
+          }
+        ]
+      },
+      "agreement-already-cancelled2": {
+        "title": "AGREEMENT_ALREADY_CANCELLED_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/agreement-already-cancelled2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/agreement-already-cancelled2-description"
+          }
+        }
+      },
+      "billing-agreement-not-found2": {
+        "title": "BILLING_AGREEMENT_NOT_FOUND_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-agreement-not-found2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-agreement-not-found2-description"
+          }
+        }
+      },
+      "declined-due-to-related-txn1": {
+        "title": "DECLINED_DUE_TO_RELATED_TXN_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/declined-due-to-related-txn1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/declined-due-to-related-txn1-description"
+          }
+        }
+      },
+      "missing-previous-reference3": {
+        "title": "MISSING_PREVIOUS_REFERENCE_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-previous-reference3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-previous-reference3-description"
+          }
+        }
+      },
+      "missing-cryptogram3": {
+        "title": "MISSING_CRYPTOGRAM_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-cryptogram3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-cryptogram3-description"
+          }
+        }
+      },
+      "card-brand-not-supported1": {
+        "title": "CARD_BRAND_NOT_SUPPORTED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-brand-not-supported1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-brand-not-supported1-description"
+          }
+        }
+      },
+      "compliance-violation1": {
+        "title": "COMPLIANCE_VIOLATION_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/compliance-violation1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/compliance-violation1-description"
+          }
+        }
+      },
+      "domestic-transaction-required2": {
+        "title": "DOMESTIC_TRANSACTION_REQUIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/domestic-transaction-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/domestic-transaction-required2-description"
+          }
+        }
+      },
+      "duplicate-invoice-id2": {
+        "title": "DUPLICATE_INVOICE_ID_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/duplicate-invoice-id2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/duplicate-invoice-id2-description"
+          }
+        }
+      },
+      "instrument-declined1": {
+        "title": "INSTRUMENT_DECLINED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/instrument-declined1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/instrument-declined1-description"
+          }
+        }
+      },
+      "order-not-approved1": {
+        "title": "ORDER_NOT_APPROVED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-not-approved1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-not-approved1-description"
+          }
+        }
+      },
+      "max-number-of-payment-attempts-exceeded2": {
+        "title": "MAX_PAYMENT_ATTEMPTS_EXCEEDED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/max-number-of-payment-attempts-exceeded2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/exceeded-max-payment-attempts-desc"
+          }
+        }
+      },
+      "payee-blocked-transaction2": {
+        "title": "PAYEE_BLOCKED_TRANSACTION_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-blocked-transaction2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-blocked-transaction2-description"
+          }
+        }
+      },
+      "payee-fx-rate-id-expired3": {
+        "title": "PAYEE_FX_RATE_ID_EXPIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-fx-rate-id-expired3-description"
+          }
+        }
+      },
+      "payer-account-locked-or-closed2": {
+        "title": "PAYER_ACCOUNT_LOCKED_OR_CLOSED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-account-locked-or-closed2-description"
+          }
+        }
+      },
+      "payer-account-restricted2": {
+        "title": "PAYER_ACCOUNT_RESTRICTED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-account-restricted2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-account-restricted2-description"
+          }
+        }
+      },
+      "payer-cannot-pay2": {
+        "title": "PAYER_CANNOT_PAY_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-cannot-pay2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-cannot-pay2-description"
+          }
+        }
+      },
+      "paypal-transaction-id-expired1": {
+        "title": "PAYPAL_TRANSACTION_ID_EXPIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-transaction-id-expired1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-expired1-description"
+          }
+        }
+      },
+      "pnref-expired1": {
+        "title": "PNREF_EXPIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/pnref-expired1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/pnref-expired1-description"
+          }
+        }
+      },
+      "referenced-card-expired1": {
+        "title": "REFERENCED_CARD_EXPIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/referenced-card-expired1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/referenced-card-expired1-description"
+          }
+        }
+      },
+      "token-id-not-found1": {
+        "title": "TOKEN_ID_NOT_FOUND_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/token-id-not-found1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/token-id-not-found1-description"
+          }
+        }
+      },
+      "transaction-limit-exceeded2": {
+        "title": "TRANSACTION_LIMIT_EXCEEDED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-limit-exceeded2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-limit-exceeded2-description"
+          }
+        }
+      },
+      "transaction-receiving-limit-exceeded2": {
+        "title": "TRANSACTION_RECEIVE_LIMIT_EXCEEDED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-receiving-limit-exceeded2-description"
+          }
+        }
+      },
+      "transaction-refused2": {
+        "title": "TRANSACTION_REFUSED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-refused2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-refused2-description"
+          }
+        }
+      },
+      "redirect-payer-for-alternate-funding": {
+        "title": "REDIRECT_PAYER_FOR_ALTERNATE_FUNDING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/redirect-payer-for-alternate-funding-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/redirect-payer-for-alternate-funding-description"
+          }
+        }
+      },
+      "order-already-captured1": {
+        "title": "ORDER_ALREADY_CAPTURED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-already-captured1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-already-captured1-description"
+          }
+        }
+      },
+      "transaction-blocked-by-payee1": {
+        "title": "TRANSACTION_BLOCKED_BY_PAYEE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/transaction-blocked-by-payee1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/transaction-blocked-by-payee1-description"
+          }
+        }
+      },
+      "auth-capture-not-enabled2": {
+        "title": "AUTH_CAPTURE_NOT_ENABLED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/auth-capture-not-enabled2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/auth-capture-not-enabled2-description"
+          }
+        }
+      },
+      "not-enabled-for-bank-processing": {
+        "title": "NOT_ENABLED_FOR_BANK_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-enabled-for-bank-processing-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-enabled-for-bank-processing-description"
+          }
+        }
+      },
+      "payee-not-enabled-for-bank-processing": {
+        "title": "PAYEE_NOT_ENABLED_FOR_BANK_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-not-enabled-for-bank-processing-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-not-enabled-for-bank-processing-description"
+          }
+        }
+      },
+      "payee-not-enabled-for-card-processing": {
+        "title": "PAYEE_NOT_ENABLED_FOR_CARD_PROCESSING",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payee-not-enabled-for-card-processing-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payee-not-enabled-for-card-processing-description"
+          }
+        }
+      },
+      "invalid-pickup-address1": {
+        "title": "INVALID_PICKUP_ADDRESS_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-pickup-address1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-pickup-address1-description"
+          }
+        }
+      },
+      "shipping-address-invalid3": {
+        "title": "SHIPPING_ADDRESS_INVALID_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/shipping-address-invalid3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/shipping-address-invalid3-description"
+          }
+        }
+      },
+      "payment-source-not-supported": {
+        "title": "PAYMENT_SOURCE_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-not-supported-description"
+          }
+        }
+      },
+      "order-completion-in-progress": {
+        "title": "ORDER_COMPLETION_IN_PROGRESS",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/order-completion-in-progress-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/order-completion-in-progress-description"
+          }
+        }
+      },
+      "billing-agreement-id-mismatch1": {
+        "title": "BILLING_AGREEMENT_ID_MISMATCH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/billing-agreement-id-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/billing-agreement-id-mismatch1-description"
+          }
+        }
+      },
+      "preferred-payment-source-mismatch1": {
+        "title": "PREFERRED_PAYMENT_SOURCE_MISMATCH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/preferred-payment-source-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/preferred-payment-source-mismatch1-description"
+          }
+        }
+      },
+      "incompatible-parameter-value3": {
+        "title": "INCOMPATIBLE_PARAMETER_VALUE_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/incompatible-parameter-value3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/incompatible-parameter-value3-description"
+          }
+        }
+      },
+      "invalid-previous-transaction-reference2": {
+        "title": "INVALID_PREV_TRANS_REF_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-previous-transaction-reference2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-previous-tx-reference"
+          }
+        }
+      },
+      "previous-transaction-reference-has-chargeback2": {
+        "title": "CHARGEBACK_ON_PREVIOUS_TRANS_REF_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/prev-tx-ref-has-chargeback"
+          },
+          "description": {
+            "$ref": "#/components/schemas/capture-with-chargeback-not-usable-error"
+          }
+        }
+      },
+      "previous-transaction-reference-voided2": {
+        "title": "VOIDED_PREV_TRANS_REF_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/previous-transaction-reference-voided2-description"
+          }
+        }
+      },
+      "payment-source-mismatch2": {
+        "title": "PAYMENT_SOURCE_MISMATCH_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payment-source-mismatch2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payment-source-mismatch2-description"
+          }
+        }
+      },
+      "merchant-initiated-with-security-code2": {
+        "title": "MERCHANT_INITIATED_SECURITY_CODE_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/merchant-initiated-with-security-code2-description"
+          }
+        }
+      },
+      "merchant-initiated-with-authentication-results2": {
+        "title": "MERCHANT_INITIATED_AUTH_RESULTS_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merchant-initiated-with-auth-results"
+          },
+          "description": {
+            "$ref": "#/components/schemas/err-merch-init-auth-results-3ds-invalid-desc"
+          }
+        }
+      },
+      "merchant-initiated-with-multiple-purchase-units2": {
+        "title": "MERCHANT_INITIATED_MULTI_PURCHASE_UNITS_ERROR_RESP",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/merch-init-multi-purchase-units"
+          },
+          "description": {
+            "$ref": "#/components/schemas/err-merch-init-multi-units-not-supported-desc"
+          }
+        }
+      },
+      "return-url-required2": {
+        "title": "RETURN_URL_REQUIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/return-url-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/return-url-required2-description"
+          }
+        }
+      },
+      "cancel-url-required2": {
+        "title": "CANCEL_URL_REQUIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/cancel-url-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/cancel-url-required2-description"
+          }
+        }
+      },
+      "setup-error-for-bank1": {
+        "title": "SETUP_ERROR_FOR_BANK_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/setup-error-for-bank1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/setup-error-for-bank1-description"
+          }
+        }
+      },
+      "bank-not-supported-for-verification1": {
+        "title": "BANK_NOT_SUPPORTED_FOR_VERIFICATION_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/bank-not-supported-for-verification1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/bank-not-supported-for-verification1-description"
+          }
+        }
+      },
+      "payer-action-required1": {
+        "title": "PAYER_ACTION_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/payer-action-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-action-required1-description"
+          }
+        }
+      },
+      "apple-pay-amount-mismatch3": {
+        "title": "APPLE_PAY_AMOUNT_MISMATCH_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/apple-pay-amount-mismatch3-description"
+          }
+        }
+      },
+      "currency-not-supported-for-bank1": {
+        "title": "CURRENCY_NOT_SUPPORTED_FOR_BANK_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/currency-not-supported-for-bank1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/currency-not-supported-for-bank1-description"
+          }
+        }
+      },
+      "only-one-bank-source-allowed1": {
+        "title": "ONLY_ONE_BANK_SOURCE_ALLOWED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/only-one-bank-source-allowed1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/only-one-bank-source-allowed1-description"
+          }
+        }
+      },
+      "invalid-iban1": {
+        "title": "INVALID_IBAN_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-iban1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-iban1-description"
+          }
+        }
+      },
+      "iban-country-not-supported1": {
+        "title": "IBAN_COUNTRY_NOT_SUPPORTED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/iban-country-not-supported1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/iban-country-not-supported1-description"
+          }
+        }
+      },
+      "card-number-required2": {
+        "title": "CARD_NUMBER_REQUIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-number-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-number-required2-description"
+          }
+        }
+      },
+      "card-expiry-required2": {
+        "title": "CARD_EXPIRY_REQUIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/card-expiry-required2-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/card-expiry-required2-description"
+          }
+        }
+      },
+      "vault-instruction-required3": {
+        "title": "VAULT_INSTRUCTION_REQUIRED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/vault-instruction-required3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/vault-instruction-required3-description"
+          }
+        }
+      },
+      "mismatched-vault-id-to-payment-source3": {
+        "title": "VAULT_ID_PAYMENT_SOURCE_MISMATCH_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/mismatched-vault-id-to-payment-source3-description"
+          }
+        }
+      },
+      "not-eligible-for-pnref-processing3": {
+        "title": "NOT_ELIGIBLE_FOR_PNREF_PROCESSING_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-eligible-for-pnref-processing3-description"
+          }
+        }
+      },
+      "not-eligible-for-paypal-transaction-id-processing3": {
+        "title": "PAYPAL_ID_PROCESSING_INELIGIBILITY_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-eligible-paypal-tx-id-processing-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-tx-id-processing-permission-needed-desc"
+          }
+        }
+      },
+      "paypal-transaction-id-not-found3": {
+        "title": "PAYPAL_TRANSACTION_ID_NOT_FOUND_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/paypal-transaction-id-not-found3-description"
+          }
+        }
+      },
+      "pnref-not-found3": {
+        "title": "PNREF_NOT_FOUND_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/pnref-not-found3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/pnref-not-found3-description"
+          }
+        }
+      },
+      "invalid-security-code-length3": {
+        "title": "INVALID_SECURITY_CODE_LENGTH_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-security-code-length3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-security-code-length3-description"
+          }
+        }
+      },
+      "platform-fee-payee-cannot-be-same-as-payer": {
+        "title": "PLATFORM_FEE_PAYEE_CANNOT_BE_SAME_AS_PAYER",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/platform-fee-payee-cannot-be-same-as-payer-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/payer-cannot-pay-themselves-error"
+          }
+        }
+      },
+      "required-parameter-for-customer-initiated-payment3": {
+        "title": "MISSING_PARAM_CIP_ERROR_RESP",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/required-param-for-cust-initiated-payment-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/req-param-cust-present-initiator-merch-error"
+          }
+        }
+      },
+      "identifier-not-found": {
+        "title": "IDENTIFIER_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/identifier-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/identifier-not-found-description"
+          }
+        }
+      },
+      "shipment-tracker-tracking-number-type": {
+        "description": "The type of tracking number.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/shipment_tracking_number_type"
+          }
+        ]
+      },
+      "shipment-tracker-shipment-date": {
+        "description": "The date when the shipment occurred, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_no_time"
+          }
+        ]
+      },
+      "shipment-tracker-last-updated-time": {
+        "description": "The date and time when the tracking information was last updated, in [Internet date and time format](https://tools.ietf.org/html/rfc3339#section-5.6).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/date_time"
+          }
+        ]
+      },
+      "order-tracker-request-allof1": {
+        "properties": {
+          "capture_id": {
+            "type": "string",
+            "description": "The PayPal capture ID.",
+            "minLength": 1,
+            "maxLength": 50,
+            "pattern": "^[a-zA-Z0-9]*$"
+          },
+          "notify_payer": {
+            "type": "boolean",
+            "description": "If true, sends an email notification to the payer of the PayPal transaction. The email contains the tracking information that was uploaded through the API.",
+            "default": false
+          },
+          "items": {
+            "$ref": "#/components/schemas/order-tracker-request-allof1-items"
+          }
+        },
+        "required": [
+          "capture_id"
+        ]
+      },
+      "order-tracker-request-allof1-items": {
+        "type": "array",
+        "description": "An array of details of items in the shipment.",
+        "items": {
+          "$ref": "#/components/schemas/order-tracker-request-allof1-items-items"
+        }
+      },
+      "order-tracker-request-allof1-items-items": {
+        "description": "Items in a shipment.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/tracker_item"
+          }
+        ]
+      },
+      "orders-track-create400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-track-create400-issues-items"
+        }
+      },
+      "orders-track-create400-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/missing-required-parameter5"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length5"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value5"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-syntax5"
+          }
+        ]
+      },
+      "missing-required-parameter5": {
+        "title": "MISSING_REQUIRED_PARAMETER_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter5-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter5-description"
+          }
+        }
+      },
+      "invalid-string-length5": {
+        "title": "INVALID_STRING_LENGTH_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length5-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length5-description"
+          }
+        }
+      },
+      "invalid-parameter-value5": {
+        "title": "INVALID_PARAMETER_VALUE_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value5-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value5-description"
+          }
+        }
+      },
+      "invalid-parameter-syntax5": {
+        "title": "INVALID_PARAMETER_SYNTAX_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax5-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-syntax5-description"
+          }
+        }
+      },
+      "orders-track-create403-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-track-create403-issues-items"
+        }
+      },
+      "orders-track-create403-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/permission-denied3"
+          }
+        ]
+      },
+      "permission-denied3": {
+        "title": "PERMISSION_DENIED_ERROR_RESPONSE",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied3-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied3-description"
+          }
+        }
+      },
+      "orders-track-create422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-track-create422-issues-items"
+        }
+      },
+      "orders-track-create422-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/capture-status-not-valid"
+          },
+          {
+            "$ref": "#/components/schemas/item-sku-mismatch"
+          },
+          {
+            "$ref": "#/components/schemas/capture-id-not-found"
+          },
+          {
+            "$ref": "#/components/schemas/msp-not-supported"
+          }
+        ]
+      },
+      "capture-status-not-valid": {
+        "title": "CAPTURE_STATUS_NOT_VALID",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/capture-status-not-valid-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/capture-status-not-valid-description"
+          }
+        }
+      },
+      "item-sku-mismatch": {
+        "title": "ITEM_SKU_MISMATCH",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-sku-mismatch-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/item-sku-mismatch-description"
+          }
+        }
+      },
+      "capture-id-not-found": {
+        "title": "CAPTURE_ID_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/capture-id-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/capture-id-not-found-description"
+          }
+        }
+      },
+      "msp-not-supported": {
+        "title": "MSP_NOT_SUPPORTED",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/msp-not-supported-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/msp-not-supported-description"
+          }
+        }
+      },
+      "orders-trackers-patch400-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-trackers-patch400-issues-items"
+        }
+      },
+      "orders-trackers-patch400-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/field-not-patchable1"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-parameter-value6"
+          },
+          {
+            "$ref": "#/components/schemas/missing-required-parameter6"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-string-length6"
+          },
+          {
+            "$ref": "#/components/schemas/invalid-patch-operation1"
+          },
+          {
+            "$ref": "#/components/schemas/malformed-request-json5"
+          }
+        ]
+      },
+      "field-not-patchable1": {
+        "title": "FIELD_NOT_PATCHABLE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/field-not-patchable1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/field-not-patchable1-description"
+          }
+        }
+      },
+      "invalid-parameter-value6": {
+        "title": "INVALID_PARAMETER_VALUE_ERROR_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-parameter-value6-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-parameter-value6-description"
+          }
+        }
+      },
+      "missing-required-parameter6": {
+        "title": "MISSING_REQUIRED_PARAMETER_ERROR_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/missing-required-parameter6-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/missing-required-parameter6-description"
+          }
+        }
+      },
+      "invalid-string-length6": {
+        "title": "INVALID_STRING_LENGTH_ERROR_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-string-length6-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-string-length6-description"
+          }
+        }
+      },
+      "invalid-patch-operation1": {
+        "title": "INVALID_PATCH_OPERATION_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-patch-operation1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-patch-operation1-description"
+          }
+        }
+      },
+      "malformed-request-json5": {
+        "title": "MALFORMED_REQUEST_JSON_ERROR_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/malformed-request-json5-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/malformed-request-json5-description"
+          }
+        }
+      },
+      "orders-trackers-patch403-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-trackers-patch403-issues-items"
+        }
+      },
+      "orders-trackers-patch403-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/permission-denied4"
+          }
+        ]
+      },
+      "permission-denied4": {
+        "title": "PERMISSION_DENIED_ERROR_RESULT",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/permission-denied4-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/permission-denied4-description"
+          }
+        }
+      },
+      "orders-trackers-patch404-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-trackers-patch404-issues-items"
+        }
+      },
+      "orders-trackers-patch404-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/tracker-id-not-found"
+          }
+        ]
+      },
+      "tracker-id-not-found": {
+        "title": "TRACKER_ID_NOT_FOUND",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/tracker-id-not-found-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/tracker-id-not-found-description"
+          }
+        }
+      },
+      "orders-trackers-patch422-issues": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/orders-trackers-patch422-issues-items"
+        }
+      },
+      "orders-trackers-patch422-issues-items": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/invalid-json-pointer-format1"
+          },
+          {
+            "$ref": "#/components/schemas/not-patchable1"
+          },
+          {
+            "$ref": "#/components/schemas/patch-value-required1"
+          },
+          {
+            "$ref": "#/components/schemas/patch-path-required1"
+          },
+          {
+            "$ref": "#/components/schemas/item-sku-mismatch1"
+          }
+        ]
+      },
+      "invalid-json-pointer-format1": {
+        "title": "INVALID_JSON_POINTER_FORMAT_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/invalid-json-pointer-format1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/invalid-json-pointer-format1-description"
+          }
+        }
+      },
+      "not-patchable1": {
+        "title": "NOT_PATCHABLE_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/not-patchable1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/not-patchable1-description"
+          }
+        }
+      },
+      "patch-value-required1": {
+        "title": "PATCH_VALUE_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/patch-value-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/patch-value-required1-description"
+          }
+        }
+      },
+      "patch-path-required1": {
+        "title": "PATCH_PATH_REQUIRED_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/patch-path-required1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/patch-path-required1-description"
+          }
+        }
+      },
+      "item-sku-mismatch1": {
+        "title": "ITEM_SKU_MISMATCH_ERROR",
+        "properties": {
+          "issue": {
+            "$ref": "#/components/schemas/item-sku-mismatch1-issue"
+          },
+          "description": {
+            "$ref": "#/components/schemas/item-sku-mismatch1-description"
+          }
+        }
+      },
+      "invalid-array-max-items-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_ARRAY_MAX_ITEMS"
+        ]
+      },
+      "invalid-array-max-items-description": {
+        "type": "string",
+        "enum": [
+          "The number of items in an array parameter is too large."
+        ]
+      },
+      "invalid-array-min-items-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_ARRAY_MIN_ITEMS"
+        ]
+      },
+      "invalid-array-min-items-description": {
+        "type": "string",
+        "enum": [
+          "The number of items in an array parameter is too small."
+        ]
+      },
+      "invalid-country-code-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_COUNTRY_CODE"
+        ]
+      },
+      "invalid-country-code-description": {
+        "type": "string",
+        "enum": [
+          "Country code is invalid. Please refer to https://developer.paypal.com/api/rest/reference/country-codes/ for a list of supported country codes."
+        ]
+      },
+      "invalid-parameter-syntax-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_SYNTAX"
+        ]
+      },
+      "invalid-parameter-syntax-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field does not conform to the expected format."
+        ]
+      },
+      "invalid-string-length-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long"
+        ]
+      },
+      "invalid-parameter-value-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value-description": {
+        "type": "string",
+        "enum": [
+          "A parameter value is not valid."
+        ]
+      },
+      "missing-required-parameter-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter-description": {
+        "type": "string",
+        "enum": [
+          "A required parameter is missing."
+        ]
+      },
+      "not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_SUPPORTED"
+        ]
+      },
+      "not-supported-description": {
+        "type": "string",
+        "enum": [
+          "This field is not currently supported."
+        ]
+      },
+      "paypal-request-id-required-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_REQUEST_ID_REQUIRED"
+        ]
+      },
+      "paypal-request-id-required-description": {
+        "type": "string",
+        "enum": [
+          "A PayPal-Request-Id is required if you are trying to process payment for an Order. Please specify a PayPal-Request-Id or Create the Order without a 'payment_source' specified."
+        ]
+      },
+      "malformed-request-json-issue": {
+        "type": "string",
+        "enum": [
+          "MALFORMED_REQUEST_JSON"
+        ]
+      },
+      "malformed-request-json-description": {
+        "type": "string",
+        "enum": [
+          "The request JSON is not well formed."
+        ]
+      },
+      "invalid-account-status-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_ACCOUNT_STATUS"
+        ]
+      },
+      "invalid-account-status-description": {
+        "type": "string",
+        "enum": [
+          "Account validations failed for the user."
+        ]
+      },
+      "permission-denied-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED"
+        ]
+      },
+      "permission-denied-description": {
+        "type": "string",
+        "enum": [
+          "You do not have permission to access or perform operations on this resource."
+        ]
+      },
+      "payee-account-not-verified-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_ACCOUNT_NOT_VERIFIED"
+        ]
+      },
+      "payee-account-not-verified-description": {
+        "type": "string",
+        "enum": [
+          "Payee has not verified their account with PayPal. The selected payment method requires the recipient to have a verified PayPal account before transactions can be processed on their behalf."
+        ]
+      },
+      "invalid-resource-id-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_RESOURCE_ID"
+        ]
+      },
+      "invalid-resource-id-description": {
+        "type": "string",
+        "enum": [
+          "Specified resource ID does not exist. Please check the resource ID and try again."
+        ]
+      },
+      "amount-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "AMOUNT_MISMATCH"
+        ]
+      },
+      "amount-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount."
+        ]
+      },
+      "cannot-be-negative-issue": {
+        "type": "string",
+        "enum": [
+          "CANNOT_BE_NEGATIVE"
+        ]
+      },
+      "cannot-be-negative-description": {
+        "type": "string",
+        "enum": [
+          "Must be greater than or equal to 0. If the currency supports decimals, only two decimal place precision is supported."
+        ]
+      },
+      "cannot-be-zero-or-negative-issue": {
+        "type": "string",
+        "enum": [
+          "CANNOT_BE_ZERO_OR_NEGATIVE"
+        ]
+      },
+      "cannot-be-zero-or-negative-description": {
+        "type": "string",
+        "enum": [
+          "Must be greater than zero. If the currency supports decimals, only two decimal place precision is supported."
+        ]
+      },
+      "card-expired-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_EXPIRED"
+        ]
+      },
+      "card-expired-description": {
+        "type": "string",
+        "enum": [
+          "The card is expired"
+        ]
+      },
+      "missing-previous-reference-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_PREVIOUS_REFERENCE"
+        ]
+      },
+      "missing-previous-reference-description": {
+        "type": "string",
+        "enum": [
+          "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
+        ]
+      },
+      "missing-cryptogram-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_CRYPTOGRAM"
+        ]
+      },
+      "missing-cryptogram-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is mandatory for any customer initiated network token transactions."
+        ]
+      },
+      "city-required-issue": {
+        "type": "string",
+        "enum": [
+          "CITY_REQUIRED"
+        ]
+      },
+      "city-required-description": {
+        "type": "string",
+        "enum": [
+          "The specified country requires a city (address.admin_area_2)."
+        ]
+      },
+      "decimal-precision-issue": {
+        "type": "string",
+        "enum": [
+          "DECIMAL_PRECISION"
+        ]
+      },
+      "decimal-precision-description": {
+        "type": "string",
+        "enum": [
+          "If the currency supports decimals, only two decimal place precision is supported."
+        ]
+      },
+      "donation-items-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "DONATION_ITEMS_NOT_SUPPORTED"
+        ]
+      },
+      "donation-items-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "If 'purchase_unit' has \"DONATION\" as the 'items.category' then the Order can at most have one purchase_unit. Multiple purchase_units are not supported if either of them have at least one items with category as \"DONATION\"."
+        ]
+      },
+      "duplicate-reference-id-issue": {
+        "type": "string",
+        "enum": [
+          "DUPLICATE_REFERENCE_ID"
+        ]
+      },
+      "duplicate-reference-id-description": {
+        "type": "string",
+        "enum": [
+          "`reference_id` must be unique if multiple `purchase_unit` are provided."
+        ]
+      },
+      "invalid-currency-code-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_CURRENCY_CODE"
+        ]
+      },
+      "invalid-currency-code-description": {
+        "type": "string",
+        "enum": [
+          "Currency code is invalid or is not currently supported. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
+        ]
+      },
+      "invalid-payer-id-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PAYER_ID"
+        ]
+      },
+      "invalid-payer-id-description": {
+        "type": "string",
+        "enum": [
+          "The payer ID is not valid."
+        ]
+      },
+      "item-total-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "ITEM_TOTAL_MISMATCH"
+        ]
+      },
+      "item-total-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "Should equal sum of (unit_amount * quantity) across all items for a given purchase_unit."
+        ]
+      },
+      "item-total-required-issue": {
+        "type": "string",
+        "enum": [
+          "ITEM_TOTAL_REQUIRED"
+        ]
+      },
+      "item-total-required-description": {
+        "type": "string",
+        "enum": [
+          "If item details are specified (items.unit_amount and items.quantity) corresponding amount.breakdown.item_total is required."
+        ]
+      },
+      "max-value-exceeded-issue": {
+        "type": "string",
+        "enum": [
+          "MAX_VALUE_EXCEEDED"
+        ]
+      },
+      "max-value-exceeded-description": {
+        "type": "string",
+        "enum": [
+          "Should be less than or equal to 999999999999999.99."
+        ]
+      },
+      "missing-pickup-address-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_PICKUP_ADDRESS"
+        ]
+      },
+      "missing-pickup-address-description": {
+        "type": "string",
+        "enum": [
+          "A pickup address(`shipping.address`) is required for the provided `shipping.type`."
+        ]
+      },
+      "multi-currency-order-issue": {
+        "type": "string",
+        "enum": [
+          "MULTI_CURRENCY_ORDER"
+        ]
+      },
+      "multi-currency-order-description": {
+        "type": "string",
+        "enum": [
+          "Multiple differing values of currency_code are not supported. Entire Order request must have the same currency_code."
+        ]
+      },
+      "multiple-item-categories-issue": {
+        "type": "string",
+        "enum": [
+          "MULTIPLE_ITEM_CATEGORIES"
+        ]
+      },
+      "multiple-item-categories-description": {
+        "type": "string",
+        "enum": [
+          "For a given 'purchase_unit' the 'items.category' could be either \"PHYSICAL_GOODS\" and/or \"DIGITAL_GOODS\" or just \"DONATION\".  'items.category' as \"DONATION\" cannot be combined with items with either \"PHYSICAL_GOODS\" or \"DIGITAL_GOODS\"."
+        ]
+      },
+      "multiple-shipping-address-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "MULTIPLE_SHIPPING_ADDRESS_NOT_SUPPORTED"
+        ]
+      },
+      "multiple-shipping-addresses-not-supported": {
+        "type": "string",
+        "enum": [
+          "Multiple shipping addresses are not supported."
+        ]
+      },
+      "multiple-shipping-type-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "MULTIPLE_SHIPPING_TYPE_NOT_SUPPORTED"
+        ]
+      },
+      "multiple-shipping-type-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "Different `shipping.type` are not supported across purchase units."
+        ]
+      },
+      "payee-account-invalid-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_ACCOUNT_INVALID"
+        ]
+      },
+      "payee-account-invalid-description": {
+        "type": "string",
+        "enum": [
+          "Payee account specified is invalid. Please check the `payee.email_address` or `payee.merchant_id` specified and try again. Ensure that either  `payee.merchant_id` or `payee.email_address` is specified."
+        ]
+      },
+      "payee-account-locked-or-closed-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_ACCOUNT_LOCKED_OR_CLOSED"
+        ]
+      },
+      "payee-account-locked-or-closed-description": {
+        "type": "string",
+        "enum": [
+          "The merchant account is locked or closed."
+        ]
+      },
+      "payee-account-restricted-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payee-account-restricted-description": {
+        "type": "string",
+        "enum": [
+          "The merchant account is restricted."
+        ]
+      },
+      "payee-pricing-tier-id-not-enabled-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_PRICING_TIER_ID_NOT_ENABLED"
+        ]
+      },
+      "payee-pricing-tier-id-not-enabled-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller is not enabled to process transactions by specifying a 'payee_pricing_tier_id'. Please work with your Account Manager to enable this option for your account."
+        ]
+      },
+      "invalid-payee-pricing-tier-id-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PAYEE_PRICING_TIER_ID"
+        ]
+      },
+      "invalid-payee-pricing-tier-id-description": {
+        "type": "string",
+        "enum": [
+          "Please check the value specified or confirm with your Account Manager that the 'payee_pricing_tier_id' specified has been setup for the account."
+        ]
+      },
+      "payee-fx-rate-id-expired-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_FX_RATE_ID_EXPIRED"
+        ]
+      },
+      "payee-fx-rate-id-expired-description": {
+        "type": "string",
+        "enum": [
+          "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
+        ]
+      },
+      "payee-fx-rate-id-currency-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH"
+        ]
+      },
+      "payee-fx-rate-id-currency-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "The specified FX Rate ID is for a currency that does not match with the currency of this request. Please specify a different FX Rate ID and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
+        ]
+      },
+      "invalid-fx-rate-id-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_FX_RATE_ID"
+        ]
+      },
+      "invalid-fx-rate-id-description": {
+        "type": "string",
+        "enum": [
+          "The specific FX Rate ID is not valid. This could be either because we are not able to look up the FX Rate based on this ID or it could be because the ID belongs to another API Caller."
+        ]
+      },
+      "platform-fees-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "PLATFORM_FEES_NOT_SUPPORTED"
+        ]
+      },
+      "platform-fees-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller is not enabled to process transactions by specifying 'platform_fees'. Please work with your PayPal Account Manager to enable this option for your account."
+        ]
+      },
+      "invalid-platform-fees-account-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PLATFORM_FEES_ACCOUNT"
+        ]
+      },
+      "invalid-platform-fees-account-description": {
+        "type": "string",
+        "enum": [
+          "The specified platform_fees payee account is either invalid or account setup is incomplete.Please work with your PayPal Account Manager to enable this option for your account."
+        ]
+      },
+      "invalid-platform-fees-amount-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PLATFORM_FEES_AMOUNT"
+        ]
+      },
+      "invalid-platform-fees-amount-description": {
+        "type": "string",
+        "enum": [
+          "The platform_fees amount cannot be greater than order amount."
+        ]
+      },
+      "postal-code-required-issue": {
+        "type": "string",
+        "enum": [
+          "POSTAL_CODE_REQUIRED"
+        ]
+      },
+      "postal-code-required-description": {
+        "type": "string",
+        "enum": [
+          "The specified country requires a postal code."
+        ]
+      },
+      "reference-id-required-issue": {
+        "type": "string",
+        "enum": [
+          "REFERENCE_ID_REQUIRED"
+        ]
+      },
+      "reference-id-required-description": {
+        "type": "string",
+        "enum": [
+          "'reference_id' is required for each 'purchase_unit' if multiple 'purchase_unit' are provided."
+        ]
+      },
+      "tax-total-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "TAX_TOTAL_MISMATCH"
+        ]
+      },
+      "tax-total-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "Should equal sum of (tax * quantity) across all items for a given purchase_unit."
+        ]
+      },
+      "tax-total-required-issue": {
+        "type": "string",
+        "enum": [
+          "TAX_TOTAL_REQUIRED"
+        ]
+      },
+      "tax-total-required-description": {
+        "type": "string",
+        "enum": [
+          "If item details are specified (items.tax_total and items.quantity) corresponding amount.breakdown.tax_total is required."
+        ]
+      },
+      "unsupported-intent-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_INTENT"
+        ]
+      },
+      "unsupported-intent-description": {
+        "type": "string",
+        "enum": [
+          "`intent=AUTHORIZE` is not supported for multiple purchase units. Only `intent=CAPTURE` is supported."
+        ]
+      },
+      "unsupported-payment-instruction-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_PAYMENT_INSTRUCTION"
+        ]
+      },
+      "unsupported-payment-instruction-description": {
+        "type": "string",
+        "enum": [
+          "You must provide the payment instruction when you capture an authorized payment for `intent=AUTHORIZE`. For details, see <a href=\"/docs/api/payments/v2/#authorizations_capture\">Capture authorization</a>. For `intent=CAPTURE`, send the payment instruction when you create the order."
+        ]
+      },
+      "shipping-type-not-supported-for-client-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_TYPE_NOT_SUPPORTED_FOR_CLIENT"
+        ]
+      },
+      "shipping-type-not-supported-for-client-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller account is not setup to be able to support a `shipping.type`=`PICKUP_IN_PERSON`. This feature is only supported for <a href=\"https://www.paypal.com/us/business/platforms-and-marketplaces\">PayPal Commerce Platform for Platforms and Marketplaces</a>."
+        ]
+      },
+      "unsupported-shipping-type-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_SHIPPING_TYPE"
+        ]
+      },
+      "unsupported-shipping-type-description": {
+        "type": "string",
+        "enum": [
+          "The provided `shipping.type` is only supported for `application_context.shipping_preference`=`SET_PROVIDED_ADDRESS` or `NO_SHIPPING`."
+        ]
+      },
+      "shipping-option-not-selected-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_OPTION_NOT_SELECTED"
+        ]
+      },
+      "shipping-option-not-selected-description": {
+        "type": "string",
+        "enum": [
+          "At least one of the shipping.option should be set to 'selected = true'."
+        ]
+      },
+      "multiple-shipping-option-selected-issue": {
+        "type": "string",
+        "enum": [
+          "MULTIPLE_SHIPPING_OPTION_SELECTED"
+        ]
+      },
+      "multiple-shipping-option-selected-description": {
+        "type": "string",
+        "enum": [
+          "Only one shipping.option can be set to 'selected = true'."
+        ]
+      },
+      "preferred-shipping-option-amount-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH"
+        ]
+      },
+      "preferred-shipping-amount-match-amount-breakdown": {
+        "type": "string",
+        "enum": [
+          "The amount provided in the preferred shipping option should match the amount provided in amount breakdown"
+        ]
+      },
+      "agreement-already-cancelled-issue": {
+        "type": "string",
+        "enum": [
+          "AGREEMENT_ALREADY_CANCELLED"
+        ]
+      },
+      "agreement-already-cancelled-description": {
+        "type": "string",
+        "enum": [
+          "The requested agreement is already canceled."
+        ]
+      },
+      "billing-agreement-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_AGREEMENT_NOT_FOUND"
+        ]
+      },
+      "billing-agreement-not-found-description": {
+        "type": "string",
+        "enum": [
+          "The requested Billing Agreement token was not found."
+        ]
+      },
+      "compliance-violation-issue": {
+        "type": "string",
+        "enum": [
+          "COMPLIANCE_VIOLATION"
+        ]
+      },
+      "compliance-violation-description": {
+        "type": "string",
+        "enum": [
+          "Transaction is declined due to compliance violation."
+        ]
+      },
+      "domestic-transaction-required-issue": {
+        "type": "string",
+        "enum": [
+          "DOMESTIC_TRANSACTION_REQUIRED"
+        ]
+      },
+      "domestic-transaction-required-description": {
+        "type": "string",
+        "enum": [
+          "This transaction requires the payee and payer to be resident in the same country, a domestic transaction is required to create this payment."
+        ]
+      },
+      "duplicate-invoice-id-issue": {
+        "type": "string",
+        "enum": [
+          "DUPLICATE_INVOICE_ID"
+        ]
+      },
+      "duplicate-invoice-id-description": {
+        "type": "string",
+        "enum": [
+          "Duplicate Invoice ID detected. To avoid a potential duplicate transaction your account setting requires that Invoice Id be unique for each transaction."
+        ]
+      },
+      "instrument-declined-issue": {
+        "type": "string",
+        "enum": [
+          "INSTRUMENT_DECLINED"
+        ]
+      },
+      "instrument-declined-description": {
+        "type": "string",
+        "enum": [
+          "The instrument presented  was either declined by the processor or bank, or it can't be used for this payment."
+        ]
+      },
+      "max-number-of-payment-attempts-exceeded-issue": {
+        "type": "string",
+        "enum": [
+          "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED"
+        ]
+      },
+      "exceeded-max-payment-attempts": {
+        "type": "string",
+        "enum": [
+          "You have exceeded the maximum number of payment attempts."
+        ]
+      },
+      "payee-blocked-transaction-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_BLOCKED_TRANSACTION"
+        ]
+      },
+      "payee-blocked-transaction-description": {
+        "type": "string",
+        "enum": [
+          "The Fraud settings for this seller are such that this payment cannot be executed."
+        ]
+      },
+      "payer-account-locked-or-closed-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_LOCKED_OR_CLOSED"
+        ]
+      },
+      "payer-account-locked-or-closed-description": {
+        "type": "string",
+        "enum": [
+          "The payer account cannot be used for this transaction."
+        ]
+      },
+      "payer-account-restricted-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payer-account-restricted-description": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payer-cannot-pay-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_CANNOT_PAY"
+        ]
+      },
+      "payer-cannot-pay-description": {
+        "type": "string",
+        "enum": [
+          "Combination of payer and payee settings mean that this buyer cannot pay this seller."
+        ]
+      },
+      "transaction-blocked-by-payee-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_BLOCKED_BY_PAYEE"
+        ]
+      },
+      "transaction-blocked-by-payee-description": {
+        "type": "string",
+        "enum": [
+          "Transaction blocked by Payee’s Fraud Protection settings."
+        ]
+      },
+      "transaction-limit-exceeded-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_LIMIT_EXCEEDED"
+        ]
+      },
+      "transaction-limit-exceeded-description": {
+        "type": "string",
+        "enum": [
+          "Total payment amount exceeded transaction limit."
+        ]
+      },
+      "transaction-receiving-limit-exceeded-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_RECEIVING_LIMIT_EXCEEDED"
+        ]
+      },
+      "transaction-receiving-limit-exceeded-description": {
+        "type": "string",
+        "enum": [
+          "The transaction exceeds the receiver's receiving limit."
+        ]
+      },
+      "transaction-refused-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_REFUSED"
+        ]
+      },
+      "transaction-refused-description": {
+        "type": "string",
+        "enum": [
+          "The request was refused."
+        ]
+      },
+      "auth-capture-not-enabled-issue": {
+        "type": "string",
+        "enum": [
+          "AUTH_CAPTURE_NOT_ENABLED"
+        ]
+      },
+      "auth-capture-not-enabled-description": {
+        "type": "string",
+        "enum": [
+          "Authorization and Capture feature is not enabled for the merchant. Make sure that the recipient of the funds is a verified business account."
+        ]
+      },
+      "unsupported-processing-instruction-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_PROCESSING_INSTRUCTION"
+        ]
+      },
+      "unsupported-processing-instruction-description": {
+        "type": "string",
+        "enum": [
+          "The specified processing_instruction is not supported for the given payment_source. Please refer to https://developer.paypal.com/api/orders/v2/#definition-processing_instruction for the list of payment_source that can be specified with this value."
+        ]
+      },
+      "order-complete-on-payment-approval-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_COMPLETE_ON_PAYMENT_APPROVAL"
+        ]
+      },
+      "order-complete-on-payment-approval-description": {
+        "type": "string",
+        "enum": [
+          "A processing_instruction of `ORDER_COMPLETE_ON_PAYMENT_APPROVAL` is required for the specified payment_source. Please refer to the integration guide https://developer.paypal.com/docs/limited-release/alternative-payment-methods-with-orders/ for more details"
+        ]
+      },
+      "invalid-expiry-date-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_EXPIRY_DATE"
+        ]
+      },
+      "invalid-expiry-date-description": {
+        "type": "string",
+        "enum": [
+          "Expiry date is invalid. Expiry date should be a date in future and within the threshold for the payment source."
+        ]
+      },
+      "incompatible-parameter-value-issue": {
+        "type": "string",
+        "enum": [
+          "INCOMPATIBLE_PARAMETER_VALUE"
+        ]
+      },
+      "incompatible-parameter-value-description": {
+        "type": "string",
+        "enum": [
+          "The value of the field is incompatible/redundant with other fields in the order."
+        ]
+      },
+      "invalid-previous-transaction-reference-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PREVIOUS_TRANSACTION_REFERENCE"
+        ]
+      },
+      "invalid-previous-transaction-reference-description": {
+        "type": "string",
+        "enum": [
+          "The authorization or capture referenced by `previous_transaction_reference` is not valid. This could be either because the previous_transaction_reference is not found or doesn't belong to the payee. Please use a valid `previous_transaction_reference`."
+        ]
+      },
+      "previous-transaction-reference-chargeback": {
+        "type": "string",
+        "enum": [
+          "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK"
+        ]
+      },
+      "capture-with-chargeback-not-usable": {
+        "type": "string",
+        "enum": [
+          "The capture referenced by `previous_transaction_reference` has a chargeback and hence cannot be used for this order. Please use a `previous_transaction_reference` which does not have a chargeback."
+        ]
+      },
+      "previous-transaction-reference-voided-issue": {
+        "type": "string",
+        "enum": [
+          "PREVIOUS_TRANSACTION_REFERENCE_VOIDED"
+        ]
+      },
+      "previous-transaction-reference-voided-description": {
+        "type": "string",
+        "enum": [
+          "The status of authorization referenced by `previous_transaction_reference` is `VOIDED` and hence cannot be used for this order. Please use a `previous_transaction_reference` whose status is not `VOIDED`."
+        ]
+      },
+      "payment-source-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_MISMATCH"
+        ]
+      },
+      "payment-source-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "The `payment_source` in the request must match the `payment_source` used for the authorization or capture referenced by `previous_transaction_reference`. Please use `previous_transaction_reference` whose `payment_source` matches with the `payment_source` specified in the order."
+        ]
+      },
+      "merchant-initiated-with-security-code-issue": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_SECURITY_CODE"
+        ]
+      },
+      "merchant-initiated-with-security-code-description": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if `payment_source.card.security_code` is present in the order. `security_code` can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with `security_code` is the order."
+        ]
+      },
+      "merchant-initiated-authentication-results": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS"
+        ]
+      },
+      "error-merchant-initiated-with-auth-results-and-3ds": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if 3D-Secure authentication results are present in the order. 3D-Secure authentication results can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with 3D-Secure authentication results is the order."
+        ]
+      },
+      "merchant-initiated-multiple-purchase-units": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS"
+        ]
+      },
+      "error-merchant-initiated-multiple-units": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if more than one purchase_unit is present in the Order. Merchant initiated payments are not supported from orders with more than one purchase_unit. Please retry the request with multiple Order requests (one for each purchase_unit)."
+        ]
+      },
+      "payment-source-info-cannot-be-verified-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED"
+        ]
+      },
+      "payment-source-info-cannot-be-verified-description": {
+        "type": "string",
+        "enum": [
+          "The combination of the payment_source name, billing address, shipping name and shipping address could not be verified. Please correct this information and try again by creating a new order."
+        ]
+      },
+      "payment-source-declined-by-processor-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR"
+        ]
+      },
+      "payment-source-declined-by-processor-description": {
+        "type": "string",
+        "enum": [
+          "The provided payment source is declined by the processor. Please try again with a different payment source by creating a new order."
+        ]
+      },
+      "payment-source-cannot-be-used-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_CANNOT_BE_USED"
+        ]
+      },
+      "payment-source-cannot-be-used-description": {
+        "type": "string",
+        "enum": [
+          "The provided payment source cannot be used to pay for the order. Please try again with a different payment source by creating a new order."
+        ]
+      },
+      "not-enabled-for-apple-pay-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ENABLED_FOR_APPLE_PAY"
+        ]
+      },
+      "not-enabled-for-apple-pay-description": {
+        "type": "string",
+        "enum": [
+          "The 'API caller' and/or 'payee' is not setup to be able to process apple pay. Please contact your Account Manager."
+        ]
+      },
+      "not-enabled-for-google-pay-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ENABLED_FOR_GOOGLE_PAY"
+        ]
+      },
+      "not-enabled-for-google-pay-description": {
+        "type": "string",
+        "enum": [
+          "The 'API caller' and/or 'payee' is not setup to be able to process google pay. Please contact your Account Manager."
+        ]
+      },
+      "apple-pay-amount-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "APPLE_PAY_AMOUNT_MISMATCH"
+        ]
+      },
+      "apple-pay-amount-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
+        ]
+      },
+      "billing-address-invalid-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_ADDRESS_INVALID"
+        ]
+      },
+      "billing-address-invalid-description": {
+        "type": "string",
+        "enum": [
+          "Provided billing address is invalid."
+        ]
+      },
+      "shipping-address-invalid-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_ADDRESS_INVALID"
+        ]
+      },
+      "shipping-address-invalid-description": {
+        "type": "string",
+        "enum": [
+          "Provided shipping address is invalid."
+        ]
+      },
+      "vault-instruction-duplicated-issue": {
+        "type": "string",
+        "enum": [
+          "VAULT_INSTRUCTION_DUPLICATED"
+        ]
+      },
+      "vault-instruction-duplicated-description": {
+        "type": "string",
+        "enum": [
+          "Only one vault instruction is allowed. Please use `vault.store_in_vault` to provide vault instruction."
+        ]
+      },
+      "vault-instruction-required-issue": {
+        "type": "string",
+        "enum": [
+          "VAULT_INSTRUCTION_REQUIRED"
+        ]
+      },
+      "vault-instruction-required-description": {
+        "type": "string",
+        "enum": [
+          "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
+        ]
+      },
+      "mismatched-vault-id-to-payment-source-issue": {
+        "type": "string",
+        "enum": [
+          "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
+        ]
+      },
+      "mismatched-vault-id-to-payment-source-description": {
+        "type": "string",
+        "enum": [
+          "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
+        ]
+      },
+      "cryptogram-required-issue": {
+        "type": "string",
+        "enum": [
+          "CRYPTOGRAM_REQUIRED"
+        ]
+      },
+      "cryptogram-required-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
+        ]
+      },
+      "emv-data-required-issue": {
+        "type": "string",
+        "enum": [
+          "EMV_DATA_REQUIRED"
+        ]
+      },
+      "emv-data-required-description": {
+        "type": "string",
+        "enum": [
+          "EMV Data is required if authentication method is EMV."
+        ]
+      },
+      "not-eligible-for-pnref-processing-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
+        ]
+      },
+      "not-eligible-for-pnref-processing-description": {
+        "type": "string",
+        "enum": [
+          "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
+        ]
+      },
+      "not-eligible-for-paypal-id-processing": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
+        ]
+      },
+      "paypal-transaction-id-processing-permission-needed": {
+        "type": "string",
+        "enum": [
+          "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
+        ]
+      },
+      "paypal-transaction-id-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_TRANSACTION_ID_NOT_FOUND"
+        ]
+      },
+      "paypal-transaction-id-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
+        ]
+      },
+      "pnref-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "PNREF_NOT_FOUND"
+        ]
+      },
+      "pnref-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Specified `pnref` was not found. Verify the value and try the request again."
+        ]
+      },
+      "invalid-security-code-length-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_SECURITY_CODE_LENGTH"
+        ]
+      },
+      "invalid-security-code-length-description": {
+        "type": "string",
+        "enum": [
+          "The security_code length is invalid for the specified card brand."
+        ]
+      },
+      "not-enabled-to-vault-payment-source-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE"
+        ]
+      },
+      "not-enabled-to-vault-payment-source-description": {
+        "type": "string",
+        "enum": [
+          "The API caller or the merchant on whose behalf the API call is initiated is not allowed to vault the given source. Please contact PayPal customer support for assistance."
+        ]
+      },
+      "required-param-for-customer-initiated-payment": {
+        "type": "string",
+        "enum": [
+          "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
+        ]
+      },
+      "req-param-cust-present-initiator-merch": {
+        "type": "string",
+        "enum": [
+          "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
+        ]
+      },
+      "token-expired-issue": {
+        "type": "string",
+        "enum": [
+          "TOKEN_EXPIRED"
+        ]
+      },
+      "token-expired-description": {
+        "type": "string",
+        "enum": [
+          "The token is expired and cannot be used for payment."
+        ]
+      },
+      "invalid-google-pay-token-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_GOOGLE_PAY_TOKEN"
+        ]
+      },
+      "invalid-google-pay-token-description": {
+        "type": "string",
+        "enum": [
+          "The google pay token is invalid. PayPal was not able to decrypt the googlepay token or PayPal was not able to find the necessary data in the token after decryption."
+        ]
+      },
+      "google-pay-gateway-merchant-id-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH"
+        ]
+      },
+      "invalid-google-pay-merchant-id": {
+        "type": "string",
+        "enum": [
+          "The gateway merchant ID in Google Pay token is not valid. This could be because the gateway merchant Id that was authorized by payer/buyer on Google Pay does not match with the API caller of the order."
+        ]
+      },
+      "cryptogram-required1-issue": {
+        "type": "string",
+        "enum": [
+          "CRYPTOGRAM_REQUIRED"
+        ]
+      },
+      "cryptogram-required1-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
+        ]
+      },
+      "one-of-parameters-required-issue": {
+        "type": "string",
+        "enum": [
+          "ONE_OF_PARAMETERS_REQUIRED"
+        ]
+      },
+      "one-of-parameters-required-description": {
+        "type": "string",
+        "enum": [
+          "One or more field is required to continue with this request."
+        ]
+      },
+      "alias-declined-by-processor-issue": {
+        "type": "string",
+        "enum": [
+          "ALIAS_DECLINED_BY_PROCESSOR"
+        ]
+      },
+      "alias-declined-by-processor-description": {
+        "type": "string",
+        "enum": [
+          "The provided alias was declined by the processor. Please create a new order with a different alias_key and/or alias_label and try again."
+        ]
+      },
+      "blik-one-click-missing-required-parameter-issue": {
+        "type": "string",
+        "enum": [
+          "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "one-click-first-transaction-params": {
+        "type": "string",
+        "enum": [
+          "Blik's one_click flow requires one_click.auth_code and one_click.alias_label parameters for the buyer's first transaction. For all subsequent transactions,only the one_click.alias_key parameter is required."
+        ]
+      },
+      "error400-name": {
+        "type": "string",
+        "enum": [
+          "INVALID_REQUEST"
+        ]
+      },
+      "error400-message": {
+        "type": "string",
+        "enum": [
+          "Request is not well-formed, syntactically incorrect, or violates schema."
+        ]
+      },
+      "error401-name": {
+        "type": "string",
+        "enum": [
+          "AUTHENTICATION_FAILURE"
+        ]
+      },
+      "error401-message": {
+        "type": "string",
+        "enum": [
+          "Authentication failed due to missing authorization header, or invalid authentication credentials."
+        ]
+      },
+      "error403-name": {
+        "type": "string",
+        "enum": [
+          "NOT_AUTHORIZED"
+        ]
+      },
+      "error403-message": {
+        "type": "string",
+        "enum": [
+          "Authorization failed due to insufficient permissions."
+        ]
+      },
+      "error404-name": {
+        "type": "string",
+        "enum": [
+          "RESOURCE_NOT_FOUND"
+        ]
+      },
+      "error404-message": {
+        "type": "string",
+        "enum": [
+          "The specified resource does not exist."
+        ]
+      },
+      "error409-name": {
+        "type": "string",
+        "enum": [
+          "RESOURCE_CONFLICT"
+        ]
+      },
+      "error409-message": {
+        "type": "string",
+        "enum": [
+          "The server has detected a conflict while processing this request."
+        ]
+      },
+      "error415-name": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_MEDIA_TYPE"
+        ]
+      },
+      "error415-message": {
+        "type": "string",
+        "enum": [
+          "The server does not support the request payload's media type."
+        ]
+      },
+      "error422-name": {
+        "type": "string",
+        "enum": [
+          "UNPROCESSABLE_ENTITY"
+        ]
+      },
+      "error422-message": {
+        "type": "string",
+        "enum": [
+          "The requested action could not be performed, semantically incorrect, or failed business validation."
+        ]
+      },
+      "error500-name": {
+        "type": "string",
+        "enum": [
+          "INTERNAL_SERVER_ERROR"
+        ]
+      },
+      "error500-message": {
+        "type": "string",
+        "enum": [
+          "An internal server error occurred."
+        ]
+      },
+      "error500-information-link": {
+        "type": "string",
+        "description": "The information link, or URI, that shows detailed information about this error for the developer.",
+        "enum": [
+          "https://developer.paypal.com/api/orders/v2/#error-INTERNAL_SERVER_ERROR"
+        ],
+        "readOnly": true
+      },
+      "error503-name": {
+        "type": "string",
+        "enum": [
+          "SERVICE_UNAVAILABLE"
+        ]
+      },
+      "error503-message": {
+        "type": "string",
+        "enum": [
+          "Service Unavailable."
+        ]
+      },
+      "not-enabled-for-card-processing-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ENABLED_FOR_CARD_PROCESSING"
+        ]
+      },
+      "shipping-option-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_OPTIONS_NOT_SUPPORTED"
+        ]
+      },
+      "shipping-option-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "Shipping options are not supported when `shipping.type` is specified or when 'application_context.shipping_preference' is set as 'NO_SHIPPING' or 'SET_PROVIDED_ADDRESS'."
+        ]
+      },
+      "tax-info-tax-id-type": {
+        "type": "string",
+        "description": "The customer's tax ID type.",
+        "minLength": 1,
+        "maxLength": 14,
+        "pattern": "^[A-Z0-9_]+$",
+        "enum": [
+          "BR_CPF",
+          "BR_CNPJ"
+        ]
+      },
+      "item-category": {
+        "type": "string",
+        "description": "The item category type.",
+        "minLength": 1,
+        "maxLength": 20,
+        "enum": [
+          "DIGITAL_GOODS",
+          "PHYSICAL_GOODS",
+          "DONATION"
+        ]
+      },
+      "shipping-detail-type": {
+        "description": "The method by which the payer wants to get their items from the payee e.g shipping, in-person pickup. Either type or options but not both may be present.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "SHIPPING",
+          "PICKUP_IN_PERSON"
+        ]
+      },
+      "token-type": {
+        "type": "string",
+        "description": "The tokenization method that generated the ID.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_-]+$",
+        "enum": [
+          "BILLING_AGREEMENT"
+        ]
+      },
+      "vault-paypal-wallet-base-allof1-usage-pattern": {
+        "type": "string",
+        "description": "Expected business/pricing model for the billing agreement.",
+        "minLength": 1,
+        "maxLength": 30,
+        "enum": [
+          "IMMEDIATE",
+          "DEFERRED",
+          "RECURRING_PREPAID",
+          "RECURRING_POSTPAID",
+          "THRESHOLD_PREPAID",
+          "THRESHOLD_POSTPAID"
+        ]
+      },
+      "vault-paypal-wallet-base-allof1-usage-type": {
+        "type": "string",
+        "description": "The usage type associated with the PayPal payment token.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "MERCHANT",
+          "PLATFORM"
+        ]
+      },
+      "vault-paypal-wallet-base-allof1-customer-type": {
+        "type": "string",
+        "description": "The customer type associated with the PayPal payment token. This is to indicate whether the customer acting on the merchant / platform is either a business or a consumer.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "default": "CONSUMER",
+        "enum": [
+          "CONSUMER",
+          "BUSINESS"
+        ]
+      },
+      "shipping-address-source-location": {
+        "type": "string",
+        "description": "The location from which the shipping address is derived.",
+        "minLength": 1,
+        "maxLength": 24,
+        "pattern": "^[A-Z_]+$",
+        "default": "GET_FROM_FILE",
+        "enum": [
+          "GET_FROM_FILE",
+          "NO_SHIPPING",
+          "SET_PROVIDED_ADDRESS"
+        ]
+      },
+      "paypal-wallet-experience-context-landing-page": {
+        "type": "string",
+        "description": "The type of landing page to show on the PayPal site for customer checkout.",
+        "default": "NO_PREFERENCE",
+        "minLength": 1,
+        "maxLength": 13,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "LOGIN",
+          "GUEST_CHECKOUT",
+          "NO_PREFERENCE"
+        ]
+      },
+      "paypal-wallet-experience-context-user-action": {
+        "type": "string",
+        "description": "Configures a <strong>Continue</strong> or <strong>Pay Now</strong> checkout flow.",
+        "default": "CONTINUE",
+        "minLength": 1,
+        "maxLength": 8,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "CONTINUE",
+          "PAY_NOW"
+        ]
+      },
+      "merchant-preferred-payment-methods": {
+        "type": "string",
+        "description": "The merchant-preferred payment methods.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "default": "UNRESTRICTED",
+        "enum": [
+          "UNRESTRICTED",
+          "IMMEDIATE_PAYMENT_REQUIRED"
+        ]
+      },
+      "experience-context-base-shipping-preference": {
+        "type": "string",
+        "description": "The location from which the shipping address is derived.",
+        "minLength": 1,
+        "maxLength": 24,
+        "pattern": "^[A-Z_]+$",
+        "default": "GET_FROM_FILE",
+        "enum": [
+          "GET_FROM_FILE",
+          "NO_SHIPPING",
+          "SET_PROVIDED_ADDRESS"
+        ]
+      },
+      "apple-pay-decrypted-token-data-payment-data-type": {
+        "description": "Indicates the type of payment data passed, in case of Non China the payment data is 3DSECURE and for China it is EMV.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 16,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "3DSECURE",
+          "EMV"
+        ]
+      },
+      "shipping-address-derive-location": {
+        "type": "string",
+        "description": "The location from which the shipping address is derived.",
+        "minLength": 1,
+        "maxLength": 24,
+        "pattern": "^[A-Z_]+$",
+        "default": "GET_FROM_FILE",
+        "enum": [
+          "GET_FROM_FILE",
+          "NO_SHIPPING",
+          "SET_PROVIDED_ADDRESS"
+        ]
+      },
+      "vault-venmo-wallet-base-allof1-usage-pattern": {
+        "type": "string",
+        "description": "Expected business/pricing model for the billing agreement.",
+        "minLength": 1,
+        "maxLength": 30,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "IMMEDIATE",
+          "DEFERRED",
+          "RECURRING_PREPAID",
+          "RECURRING_POSTPAID",
+          "THRESHOLD_PREPAID",
+          "THRESHOLD_POSTPAID"
+        ]
+      },
+      "vault-venmo-wallet-base-allof1-usage-type": {
+        "type": "string",
+        "description": "The usage type associated with the Venmo payment token.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "MERCHANT",
+          "PLATFORM"
+        ]
+      },
+      "vault-venmo-wallet-base-allof1-customer-type": {
+        "type": "string",
+        "description": "The customer type associated with the Venmo payment token. This is to indicate whether the customer acting on the merchant / platform is either a business or a consumer.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "default": "CONSUMER",
+        "enum": [
+          "CONSUMER",
+          "BUSINESS"
+        ]
+      },
+      "payment-method-standard-entry-class-code": {
+        "type": "string",
+        "description": "NACHA (the regulatory body governing the ACH network) requires that API callers (merchants, partners) obtain the consumer’s explicit authorization before initiating a transaction. To stay compliant, you’ll need to make sure that you retain a compliant authorization for each transaction that you originate to the ACH Network using this API. ACH transactions are categorized (using SEC codes) by how you capture authorization from the Receiver (the person whose bank account is being debited or credited). PayPal supports the following SEC codes.",
+        "default": "WEB",
+        "minLength": 3,
+        "maxLength": 255,
+        "enum": [
+          "TEL",
+          "WEB",
+          "CCD",
+          "PPD"
+        ]
+      },
+      "order-application-context-landing-page": {
+        "type": "string",
+        "description": "DEPRECATED. DEPRECATED. The type of landing page to show on the PayPal site for customer checkout.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.landing_page`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
+        "deprecated": true,
+        "default": "NO_PREFERENCE",
+        "minLength": 1,
+        "maxLength": 13,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "LOGIN",
+          "BILLING",
+          "NO_PREFERENCE"
+        ]
+      },
+      "order-application-context-shipping-preference": {
+        "type": "string",
+        "description": "DEPRECATED. DEPRECATED. The shipping preference:<ul><li>Displays the shipping address to the customer.</li><li>Enables the customer to choose an address on the PayPal site.</li><li>Restricts the customer from changing the address during the payment-approval process.</li></ul>.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.shipping_preference`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
+        "deprecated": true,
+        "default": "GET_FROM_FILE",
+        "minLength": 1,
+        "maxLength": 20,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "GET_FROM_FILE",
+          "NO_SHIPPING",
+          "SET_PROVIDED_ADDRESS"
+        ]
+      },
+      "order-application-context-user-action": {
+        "type": "string",
+        "description": "DEPRECATED. Configures a <strong>Continue</strong> or <strong>Pay Now</strong> checkout flow.  The fields in `application_context` are now available in the `experience_context` object under the `payment_source` which supports them (eg. `payment_source.paypal.experience_context.user_action`). Please specify this field in the `experience_context` object instead of the `application_context` object.",
+        "default": "CONTINUE",
+        "minLength": 1,
+        "maxLength": 8,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "CONTINUE",
+          "PAY_NOW"
+        ]
+      },
+      "link-description-method": {
+        "type": "string",
+        "description": "The HTTP method required to make the related call.",
+        "enum": [
+          "GET",
+          "POST",
+          "PUT",
+          "DELETE",
+          "HEAD",
+          "CONNECT",
+          "OPTIONS",
+          "PATCH"
+        ]
+      },
+      "vault-response-status": {
+        "type": "string",
+        "description": "The vault status.",
+        "minLength": 1,
+        "maxLength": 255,
+        "pattern": "^[0-9A-Z_]+$",
+        "deprecated": true,
+        "enum": [
+          "VAULTED",
+          "CREATED",
+          "APPROVED"
+        ]
+      },
+      "card-response-type": {
+        "type": "string",
+        "description": "The payment card type.",
+        "readOnly": true,
+        "enum": [
+          "CREDIT",
+          "DEBIT",
+          "PREPAID",
+          "UNKNOWN"
+        ]
+      },
+      "authorization-status-details-reason": {
+        "description": "The reason why the authorized status is `PENDING`.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 24,
+        "pattern": "^[A-Z_]+$",
+        "enum": [
+          "PENDING_REVIEW"
+        ]
+      },
+      "authorization-status-status": {
+        "description": "The status for the authorized payment.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "CREATED",
+          "CAPTURED",
+          "DENIED",
+          "PARTIALLY_CAPTURED",
+          "VOIDED",
+          "PENDING"
+        ]
+      },
+      "seller-protection-status": {
+        "type": "string",
+        "description": "Indicates whether the transaction is eligible for seller protection. For information, see [PayPal Seller Protection for Merchants](https://www.paypal.com/us/webapps/mpp/security/seller-protection).",
+        "readOnly": true,
+        "enum": [
+          "ELIGIBLE",
+          "PARTIALLY_ELIGIBLE",
+          "NOT_ELIGIBLE"
+        ]
+      },
+      "seller-protection-dispute-categories-items": {
+        "type": "string",
+        "description": "The condition that is covered for the transaction.",
+        "enum": [
+          "ITEM_NOT_RECEIVED",
+          "UNAUTHORIZED_TRANSACTION"
+        ]
+      },
+      "processor-response-avs-code": {
+        "description": "The address verification code for Visa, Discover, Mastercard, or American Express transactions.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "A",
+          "B",
+          "C",
+          "D",
+          "E",
+          "F",
+          "G",
+          "I",
+          "M",
+          "N",
+          "P",
+          "R",
+          "S",
+          "U",
+          "W",
+          "X",
+          "Y",
+          "Z",
+          "Null",
+          "0",
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      "processor-response-cvv-code": {
+        "description": "The card verification value code for for Visa, Discover, Mastercard, or American Express.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "E",
+          "I",
+          "M",
+          "N",
+          "P",
+          "S",
+          "U",
+          "X",
+          "All others",
+          "0",
+          "1",
+          "2",
+          "3",
+          "4"
+        ]
+      },
+      "processor-response-response-code": {
+        "description": "Processor response code for the non-PayPal payment processor errors.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "0000",
+          "00N7",
+          "0100",
+          "0390",
+          "0500",
+          "0580",
+          "0800",
+          "0880",
+          "0890",
+          "0960",
+          "0R00",
+          "1000",
+          "10BR",
+          "1300",
+          "1310",
+          "1312",
+          "1317",
+          "1320",
+          "1330",
+          "1335",
+          "1340",
+          "1350",
+          "1352",
+          "1360",
+          "1370",
+          "1380",
+          "1382",
+          "1384",
+          "1390",
+          "1393",
+          "5100",
+          "5110",
+          "5120",
+          "5130",
+          "5135",
+          "5140",
+          "5150",
+          "5160",
+          "5170",
+          "5180",
+          "5190",
+          "5200",
+          "5210",
+          "5400",
+          "5500",
+          "5650",
+          "5700",
+          "5710",
+          "5800",
+          "5900",
+          "5910",
+          "5920",
+          "5930",
+          "5950",
+          "6300",
+          "7600",
+          "7700",
+          "7710",
+          "7800",
+          "7900",
+          "8000",
+          "8010",
+          "8020",
+          "8030",
+          "8100",
+          "8110",
+          "8220",
+          "9100",
+          "9500",
+          "9510",
+          "9520",
+          "9530",
+          "9540",
+          "9600",
+          "PCNR",
+          "PCVV",
+          "PP06",
+          "PPRN",
+          "PPAD",
+          "PPAB",
+          "PPAE",
+          "PPAG",
+          "PPAI",
+          "PPAR",
+          "PPAU",
+          "PPAV",
+          "PPAX",
+          "PPBG",
+          "PPC2",
+          "PPCE",
+          "PPCO",
+          "PPCR",
+          "PPCT",
+          "PPCU",
+          "PPD3",
+          "PPDC",
+          "PPDI",
+          "PPDV",
+          "PPDT",
+          "PPEF",
+          "PPEL",
+          "PPER",
+          "PPEX",
+          "PPFE",
+          "PPFI",
+          "PPFR",
+          "PPFV",
+          "PPGR",
+          "PPH1",
+          "PPIF",
+          "PPII",
+          "PPIM",
+          "PPIT",
+          "PPLR",
+          "PPLS",
+          "PPMB",
+          "PPMC",
+          "PPMD",
+          "PPNC",
+          "PPNL",
+          "PPNM",
+          "PPNT",
+          "PPPH",
+          "PPPI",
+          "PPPM",
+          "PPQC",
+          "PPRE",
+          "PPRF",
+          "PPRR",
+          "PPS0",
+          "PPS1",
+          "PPS2",
+          "PPS3",
+          "PPS4",
+          "PPS5",
+          "PPS6",
+          "PPSC",
+          "PPSD",
+          "PPSE",
+          "PPTE",
+          "PPTF",
+          "PPTI",
+          "PPTR",
+          "PPTT",
+          "PPTV",
+          "PPUA",
+          "PPUC",
+          "PPUE",
+          "PPUI",
+          "PPUP",
+          "PPUR",
+          "PPVC",
+          "PPVE",
+          "PPVT"
+        ]
+      },
+      "processor-response-payment-advice-code": {
+        "description": "The declined payment transactions might have payment advice codes. The card networks, like Visa and Mastercard, return payment advice codes.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "01",
+          "02",
+          "03",
+          "21"
+        ]
+      },
+      "capture-status-details-reason": {
+        "description": "The reason why the captured payment status is `PENDING` or `DENIED`.",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 64,
+        "pattern": "^[A-Z_]+$",
+        "enum": [
+          "BUYER_COMPLAINT",
+          "CHARGEBACK",
+          "ECHECK",
+          "INTERNATIONAL_WITHDRAWAL",
+          "OTHER",
+          "PENDING_REVIEW",
+          "RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION",
+          "REFUNDED",
+          "TRANSACTION_APPROVED_AWAITING_FUNDING",
+          "UNILATERAL",
+          "VERIFICATION_REQUIRED"
+        ]
+      },
+      "capture-status-status": {
+        "description": "The status of the captured payment.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "COMPLETED",
+          "DECLINED",
+          "PARTIALLY_REFUNDED",
+          "PENDING",
+          "REFUNDED",
+          "FAILED"
+        ]
+      },
+      "refund-status-details-reason": {
+        "description": "The reason why the refund has the `PENDING` or `FAILED` status.",
+        "type": "string",
+        "enum": [
+          "ECHECK"
+        ]
+      },
+      "refund-status-status": {
+        "description": "The status of the refund.",
+        "type": "string",
+        "readOnly": true,
+        "enum": [
+          "CANCELLED",
+          "FAILED",
+          "PENDING",
+          "COMPLETED"
+        ]
+      },
+      "patch-op": {
+        "type": "string",
+        "description": "The operation.",
+        "enum": [
+          "add",
+          "remove",
+          "replace",
+          "move",
+          "copy",
+          "test"
+        ]
+      },
+      "field-not-patchable-issue": {
+        "type": "string",
+        "enum": [
+          "FIELD_NOT_PATCHABLE"
+        ]
+      },
+      "field-not-patchable-description": {
+        "type": "string",
+        "enum": [
+          "Field cannot be patched."
+        ]
+      },
+      "invalid-array-max-items1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_ARRAY_MAX_ITEMS"
+        ]
+      },
+      "invalid-array-max-items1-description": {
+        "type": "string",
+        "enum": [
+          "The number of items in an array parameter is too large."
+        ]
+      },
+      "invalid-parameter-syntax1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_SYNTAX"
+        ]
+      },
+      "invalid-parameter-syntax1-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field does not conform to the expected format."
+        ]
+      },
+      "invalid-string-length1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length1-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long"
+        ]
+      },
+      "invalid-parameter-value1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value1-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is invalid."
+        ]
+      },
+      "missing-required-parameter1-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter1-description": {
+        "type": "string",
+        "enum": [
+          "A required field / parameter is missing."
+        ]
+      },
+      "amount-not-patchable-issue": {
+        "type": "string",
+        "enum": [
+          "AMOUNT_NOT_PATCHABLE"
+        ]
+      },
+      "amount-not-patchable-description": {
+        "type": "string",
+        "enum": [
+          "The amount cannot be updated as the 'payer' has chosen and approved a specific financing offer for a given amount. Please Create a new Order with the updated Order amount and have the 'payer' approve the new payment terms."
+        ]
+      },
+      "invalid-patch-operation-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PATCH_OPERATION"
+        ]
+      },
+      "invalid-patch-operation-description": {
+        "type": "string",
+        "enum": [
+          "The operation cannot be honored. Cannot add a property that's already present, use replace. Cannot remove a property thats not present, use add. Cannot replace a property thats not present, use add."
+        ]
+      },
+      "malformed-request-json1-issue": {
+        "type": "string",
+        "enum": [
+          "MALFORMED_REQUEST_JSON"
+        ]
+      },
+      "malformed-request-json1-description": {
+        "type": "string",
+        "enum": [
+          "The request JSON is not well formed."
+        ]
+      },
+      "amount-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "AMOUNT_MISMATCH"
+        ]
+      },
+      "amount-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount."
+        ]
+      },
+      "cannot-be-negative1-issue": {
+        "type": "string",
+        "enum": [
+          "CANNOT_BE_NEGATIVE"
+        ]
+      },
+      "cannot-be-negative1-description": {
+        "type": "string",
+        "enum": [
+          "Must be greater than or equal to 0. If the currency supports decimals, only two decimal place precision is supported."
+        ]
+      },
+      "cannot-be-zero-or-negative1-issue": {
+        "type": "string",
+        "enum": [
+          "CANNOT_BE_ZERO_OR_NEGATIVE"
+        ]
+      },
+      "cannot-be-zero-or-negative1-description": {
+        "type": "string",
+        "enum": [
+          "Must be greater than zero. If the currency supports decimals, only two decimal place precision is supported."
+        ]
+      },
+      "city-required1-issue": {
+        "type": "string",
+        "enum": [
+          "CITY_REQUIRED"
+        ]
+      },
+      "city-required1-description": {
+        "type": "string",
+        "enum": [
+          "The specified country requires a city (address.admin_area_2)."
+        ]
+      },
+      "decimal-precision1-issue": {
+        "type": "string",
+        "enum": [
+          "DECIMAL_PRECISION"
+        ]
+      },
+      "decimal-precision1-description": {
+        "type": "string",
+        "enum": [
+          "If the currency supports decimals, only two decimal place precision is supported."
+        ]
+      },
+      "donation-items-not-supported1-issue": {
+        "type": "string",
+        "enum": [
+          "DONATION_ITEMS_NOT_SUPPORTED"
+        ]
+      },
+      "donation-items-not-supported1-description": {
+        "type": "string",
+        "enum": [
+          "If 'purchase_unit' has \"DONATION\" as the 'items.category' then the Order can at most have one purchase_unit. Multiple purchase_units are not supported if either of them have at least one items with category as \"DONATION\"."
+        ]
+      },
+      "duplicate-reference-id1-issue": {
+        "type": "string",
+        "enum": [
+          "DUPLICATE_REFERENCE_ID"
+        ]
+      },
+      "duplicate-reference-id1-description": {
+        "type": "string",
+        "enum": [
+          "`reference_id` must be unique if multiple `purchase_unit` are provided."
+        ]
+      },
+      "invalid-currency-code1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_CURRENCY_CODE"
+        ]
+      },
+      "invalid-currency-code1-description": {
+        "type": "string",
+        "enum": [
+          "Currency code is invalid or is not currently supported. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
+        ]
+      },
+      "item-total-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "ITEM_TOTAL_MISMATCH"
+        ]
+      },
+      "item-total-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "Should equal sum of (unit_amount * quantity) across all items for a given purchase_unit."
+        ]
+      },
+      "item-total-required1-issue": {
+        "type": "string",
+        "enum": [
+          "ITEM_TOTAL_REQUIRED"
+        ]
+      },
+      "item-total-required1-description": {
+        "type": "string",
+        "enum": [
+          "If item details are specified (items.unit_amount and items.quantity) corresponding amount.breakdown.item_total is required."
+        ]
+      },
+      "max-value-exceeded1-issue": {
+        "type": "string",
+        "enum": [
+          "MAX_VALUE_EXCEEDED"
+        ]
+      },
+      "max-value-exceeded1-description": {
+        "type": "string",
+        "enum": [
+          "Should be less than or equal to 999999999999999.99."
+        ]
+      },
+      "invalid-json-pointer-format-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_JSON_POINTER_FORMAT"
+        ]
+      },
+      "invalid-json-pointer-format-description": {
+        "type": "string",
+        "enum": [
+          "Path should be a valid JSON Pointer https://tools.ietf.org/html/rfc6901 that references a location within the request where the operation is performed."
+        ]
+      },
+      "invalid-parameter-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER"
+        ]
+      },
+      "invalid-parameter-description": {
+        "type": "string",
+        "enum": [
+          "Cannot be specified as part of the request."
+        ]
+      },
+      "not-patchable-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_PATCHABLE"
+        ]
+      },
+      "not-patchable-description": {
+        "type": "string",
+        "enum": [
+          "Cannot be patched."
+        ]
+      },
+      "tax-total-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "TAX_TOTAL_MISMATCH"
+        ]
+      },
+      "tax-total-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "Should equal sum of (tax * quantity) across all items for a given purchase_unit."
+        ]
+      },
+      "tax-total-required1-issue": {
+        "type": "string",
+        "enum": [
+          "TAX_TOTAL_REQUIRED"
+        ]
+      },
+      "tax-total-required1-description": {
+        "type": "string",
+        "enum": [
+          "If item details are specified (items.tax_total and items.quantity) corresponding amount.breakdown.tax_total is required."
+        ]
+      },
+      "unsupported-intent1-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_INTENT"
+        ]
+      },
+      "unsupported-intent1-description": {
+        "type": "string",
+        "enum": [
+          "`intent=AUTHORIZE` is not supported for multiple purchase units. Only `intent=CAPTURE` is supported."
+        ]
+      },
+      "unsupported-patch-parameter-value-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_PATCH_PARAMETER_VALUE"
+        ]
+      },
+      "unsupported-patch-parameter-value-description": {
+        "type": "string",
+        "enum": [
+          "The value specified for this field is not currently supported."
+        ]
+      },
+      "patch-value-required-issue": {
+        "type": "string",
+        "enum": [
+          "PATCH_VALUE_REQUIRED"
+        ]
+      },
+      "patch-value-required-description": {
+        "type": "string",
+        "enum": [
+          "Please specify a 'value' to for the field that is being patched."
+        ]
+      },
+      "patch-path-required-issue": {
+        "type": "string",
+        "enum": [
+          "PATCH_PATH_REQUIRED"
+        ]
+      },
+      "patch-path-required-description": {
+        "type": "string",
+        "enum": [
+          "Please specify a 'path' for the field for which the operation needs to be performed."
+        ]
+      },
+      "payee-account-locked-or-closed1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_ACCOUNT_LOCKED_OR_CLOSED"
+        ]
+      },
+      "payee-account-locked-or-closed1-description": {
+        "type": "string",
+        "enum": [
+          "The merchant account is locked or closed."
+        ]
+      },
+      "payee-account-restricted1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payee-account-restricted1-description": {
+        "type": "string",
+        "enum": [
+          "The merchant account is restricted."
+        ]
+      },
+      "payee-fx-rate-id-expired1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_FX_RATE_ID_EXPIRED"
+        ]
+      },
+      "payee-fx-rate-id-expired1-description": {
+        "type": "string",
+        "enum": [
+          "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
+        ]
+      },
+      "payee-fx-rate-id-currency-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_FX_RATE_ID_CURRENCY_MISMATCH"
+        ]
+      },
+      "payee-fx-rate-id-currency-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "The specified FX Rate ID is for a currency that does not match with the currency of this request. Please specify a different FX Rate ID and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
+        ]
+      },
+      "invalid-fx-rate-id1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_FX_RATE_ID"
+        ]
+      },
+      "invalid-fx-rate-id1-description": {
+        "type": "string",
+        "enum": [
+          "The specific FX Rate ID is not valid. This could be either because we are not able to look up the FX Rate based on this ID or it could be because the ID belongs to another API Caller."
+        ]
+      },
+      "platform-fees-not-supported1-issue": {
+        "type": "string",
+        "enum": [
+          "PLATFORM_FEES_NOT_SUPPORTED"
+        ]
+      },
+      "platform-fees-not-supported1-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller is not enabled to process transactions by specifying 'platform_fees'. Please work with your PayPal Account Manager to enable this option for your account."
+        ]
+      },
+      "invalid-platform-fees-account1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PLATFORM_FEES_ACCOUNT"
+        ]
+      },
+      "invalid-platform-fees-account1-description": {
+        "type": "string",
+        "enum": [
+          "The specified platform_fees payee account is either invalid or account setup is incomplete.Please work with your PayPal Account Manager to enable this option for your account."
+        ]
+      },
+      "invalid-platform-fees-amount1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PLATFORM_FEES_AMOUNT"
+        ]
+      },
+      "invalid-platform-fees-amount1-description": {
+        "type": "string",
+        "enum": [
+          "The platform_fees amount cannot be greater than order amount."
+        ]
+      },
+      "postal-code-required1-issue": {
+        "type": "string",
+        "enum": [
+          "POSTAL_CODE_REQUIRED"
+        ]
+      },
+      "postal-code-required1-description": {
+        "type": "string",
+        "enum": [
+          "The specified country requires a postal code."
+        ]
+      },
+      "reference-id-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "REFERENCE_ID_NOT_FOUND"
+        ]
+      },
+      "reference-id-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Filter expression value is incorrect. Please check the value of the reference_id and try again."
+        ]
+      },
+      "reference-id-required1-issue": {
+        "type": "string",
+        "enum": [
+          "REFERENCE_ID_REQUIRED"
+        ]
+      },
+      "reference-id-required1-description": {
+        "type": "string",
+        "enum": [
+          "'reference_id' is required for each 'purchase_unit' if multiple 'purchase_unit' are provided."
+        ]
+      },
+      "multi-currency-order1-issue": {
+        "type": "string",
+        "enum": [
+          "MULTI_CURRENCY_ORDER"
+        ]
+      },
+      "multi-currency-order1-description": {
+        "type": "string",
+        "enum": [
+          "Multiple differing values of currency_code are not supported. Entire Order request must have the same currency_code."
+        ]
+      },
+      "shipping-option-not-selected1-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_OPTION_NOT_SELECTED"
+        ]
+      },
+      "shipping-option-not-selected1-description": {
+        "type": "string",
+        "enum": [
+          "At least one of the shipping.option should be set to 'selected = true'."
+        ]
+      },
+      "multiple-shipping-option-selected1-issue": {
+        "type": "string",
+        "enum": [
+          "MULTIPLE_SHIPPING_OPTION_SELECTED"
+        ]
+      },
+      "multiple-shipping-option-selected1-description": {
+        "type": "string",
+        "enum": [
+          "Only one shipping.option can be set to 'selected = true'."
+        ]
+      },
+      "order-already-completed-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_ALREADY_COMPLETED"
+        ]
+      },
+      "order-already-completed-description": {
+        "type": "string",
+        "enum": [
+          "The order cannot be patched after it is completed."
+        ]
+      },
+      "preferred-shipping-option-amount-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "PREFERRED_SHIPPING_OPTION_AMOUNT_MISMATCH"
+        ]
+      },
+      "shipping-option-amount-match-breakdown": {
+        "type": "string",
+        "enum": [
+          "The amount provided in the preferred shipping option should match the amount provided in amount breakdown"
+        ]
+      },
+      "amount-change-not-allowed-issue": {
+        "type": "string",
+        "enum": [
+          "AMOUNT_CHANGE_NOT_ALLOWED"
+        ]
+      },
+      "amount-change-not-allowed-description": {
+        "type": "string",
+        "enum": [
+          "The amount specified is different from the amount authorized by payer."
+        ]
+      },
+      "invalid-parameter-syntax2-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_SYNTAX"
+        ]
+      },
+      "invalid-parameter-syntax2-description": {
+        "type": "string",
+        "enum": [
+          "The value of the field does not conform to the expected format."
+        ]
+      },
+      "invalid-parameter-value2-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value2-description": {
+        "type": "string",
+        "enum": [
+          "A parameter value is not valid."
+        ]
+      },
+      "missing-required-parameter2-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter2-description": {
+        "type": "string",
+        "enum": [
+          "A required field / parameter is missing"
+        ]
+      },
+      "invalid-string-length2-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length2-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long"
+        ]
+      },
+      "invalid-string-max-length-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_MAX_LENGTH"
+        ]
+      },
+      "invalid-string-max-length-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is too long."
+        ]
+      },
+      "malformed-request-json2-issue": {
+        "type": "string",
+        "enum": [
+          "MALFORMED_REQUEST_JSON"
+        ]
+      },
+      "malformed-request-json2-description": {
+        "type": "string",
+        "enum": [
+          "The request JSON is not well formed."
+        ]
+      },
+      "order-already-captured-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_ALREADY_CAPTURED"
+        ]
+      },
+      "order-already-captured-description": {
+        "type": "string",
+        "enum": [
+          "Order already captured. If 'intent=CAPTURE' only one capture per order is allowed."
+        ]
+      },
+      "order-already-authorized-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_ALREADY_AUTHORIZED"
+        ]
+      },
+      "order-already-authorized-description": {
+        "type": "string",
+        "enum": [
+          "Order already captured. If 'intent=CAPTURE' only one capture per order is allowed."
+        ]
+      },
+      "order-cannot-be-confirmed-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_CANNOT_BE_CONFIRMED"
+        ]
+      },
+      "order-cannot-be-confirmed-description": {
+        "type": "string",
+        "enum": [
+          "An order with status = 'COMPLETED' cannot be confirmed again."
+        ]
+      },
+      "missing-previous-reference1-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_PREVIOUS_REFERENCE"
+        ]
+      },
+      "missing-previous-reference1-description": {
+        "type": "string",
+        "enum": [
+          "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
+        ]
+      },
+      "missing-cryptogram1-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_CRYPTOGRAM"
+        ]
+      },
+      "missing-cryptogram1-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is mandatory for any customer initiated network token transactions."
+        ]
+      },
+      "currency-not-supported-for-country-issue": {
+        "type": "string",
+        "enum": [
+          "CURRENCY_NOT_SUPPORTED_FOR_COUNTRY"
+        ]
+      },
+      "currency-not-supported-for-country-description": {
+        "type": "string",
+        "enum": [
+          " For the payment_source specified, the currency of the Order is restricted by the country in which the payee account is based. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
+        ]
+      },
+      "card-expired1-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_EXPIRED"
+        ]
+      },
+      "card-expired1-description": {
+        "type": "string",
+        "enum": [
+          "The card is expired"
+        ]
+      },
+      "card-type-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_TYPE_NOT_SUPPORTED"
+        ]
+      },
+      "card-type-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "Processing of this card type is not supported. Use another card type."
+        ]
+      },
+      "currency-not-supported-for-card-type-issue": {
+        "type": "string",
+        "enum": [
+          "CURRENCY_NOT_SUPPORTED_FOR_CARD_TYPE"
+        ]
+      },
+      "currency-not-supported-for-card-type-description": {
+        "type": "string",
+        "enum": [
+          "The issued currency code of this card is not supported for direct card payments. Please refer https://developer.paypal.com/api/rest/reference/currency-codes/ for list of supported currency codes."
+        ]
+      },
+      "only-one-payment-source-allowed-issue": {
+        "type": "string",
+        "enum": [
+          "ONLY_ONE_PAYMENT_SOURCE_ALLOWED"
+        ]
+      },
+      "only-one-payment-source-allowed-description": {
+        "type": "string",
+        "enum": [
+          "More than one payment method within the payment source is not supported."
+        ]
+      },
+      "no-payment-source-provided-issue": {
+        "type": "string",
+        "enum": [
+          "NO_PAYMENT_SOURCE_PROVIDED"
+        ]
+      },
+      "no-payment-source-provided-description": {
+        "type": "string",
+        "enum": [
+          "At least one payment method is required within the payment source."
+        ]
+      },
+      "payment-already-approved-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_ALREADY_APPROVED"
+        ]
+      },
+      "payment-already-approved-description": {
+        "type": "string",
+        "enum": [
+          "The payment has already been approved.  Please capture the order, or create and confirm a new order with this payment source."
+        ]
+      },
+      "unsupported-processing-instruction1-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_PROCESSING_INSTRUCTION"
+        ]
+      },
+      "unsupported-processing-instruction1-description": {
+        "type": "string",
+        "enum": [
+          "The specified processing_instruction is not supported for the given payment_source. Please refer to https://developer.paypal.com/api/orders/v2/#definition-processing_instruction for the list of payment_source that can be specified with this value."
+        ]
+      },
+      "order-complete-on-payment-approval1-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_COMPLETE_ON_PAYMENT_APPROVAL"
+        ]
+      },
+      "order-complete-on-payment-approval1-description": {
+        "type": "string",
+        "enum": [
+          "A processing_instruction of `ORDER_COMPLETE_ON_PAYMENT_APPROVAL` is required for the specified payment_source."
+        ]
+      },
+      "invalid-expiry-date1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_EXPIRY_DATE"
+        ]
+      },
+      "invalid-expiry-date1-description": {
+        "type": "string",
+        "enum": [
+          "Expiry date is invalid. Expiry date should be a date in future and within the threshold for the payment source."
+        ]
+      },
+      "token-expired1-issue": {
+        "type": "string",
+        "enum": [
+          "TOKEN_EXPIRED"
+        ]
+      },
+      "token-expired1-description": {
+        "type": "string",
+        "enum": [
+          "The token is expired and cannot be used for payment."
+        ]
+      },
+      "invalid-google-pay-token1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_GOOGLE_PAY_TOKEN"
+        ]
+      },
+      "invalid-google-pay-token1-description": {
+        "type": "string",
+        "enum": [
+          "The google pay token is invalid. PayPal was not able to decrypt the googlepay token or PayPal was not able to find the necessary data in the token after decryption."
+        ]
+      },
+      "google-pay-gateway-merchant-id-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "GOOGLE_PAY_GATEWAY_MERCHANT_ID_MISMATCH"
+        ]
+      },
+      "invalid-google-pay-merchant-id-mismatch": {
+        "type": "string",
+        "enum": [
+          "The gateway merchant ID in Google Pay token is not valid. This could be because the gateway merchant Id that was authorized by payer/buyer on Google Pay does not match with the API caller of the order."
+        ]
+      },
+      "cryptogram-required2-issue": {
+        "type": "string",
+        "enum": [
+          "CRYPTOGRAM_REQUIRED"
+        ]
+      },
+      "cryptogram-required2-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
+        ]
+      },
+      "one-of-parameters-required1-issue": {
+        "type": "string",
+        "enum": [
+          "ONE_OF_PARAMETERS_REQUIRED"
+        ]
+      },
+      "one-of-parameters-required1-description": {
+        "type": "string",
+        "enum": [
+          "One or more field is required to continue with this request."
+        ]
+      },
+      "return-url-required-issue": {
+        "type": "string",
+        "enum": [
+          "RETURN_URL_REQUIRED"
+        ]
+      },
+      "return-url-required-description": {
+        "type": "string",
+        "enum": [
+          "The return url is required when attempting to vault this source."
+        ]
+      },
+      "cancel-url-required-issue": {
+        "type": "string",
+        "enum": [
+          "CANCEL_URL_REQUIRED"
+        ]
+      },
+      "cancel-url-required-description": {
+        "type": "string",
+        "enum": [
+          "The cancel url is required when attempting to vault this source."
+        ]
+      },
+      "country-not-supported-by-payment-source-issue": {
+        "type": "string",
+        "enum": [
+          "COUNTRY_NOT_SUPPORTED_BY_PAYMENT_SOURCE"
+        ]
+      },
+      "unsupported-country-code-payment-source": {
+        "type": "string",
+        "enum": [
+          "Country code provided is not supported by the provided payment source."
+        ]
+      },
+      "required-parameter-for-payment-source-issue": {
+        "type": "string",
+        "enum": [
+          "REQUIRED_PARAMETER_FOR_PAYMENT_SOURCE"
+        ]
+      },
+      "required-parameter-for-payment-source-description": {
+        "type": "string",
+        "enum": [
+          "The parameter is required for provided payment source."
+        ]
+      },
+      "customer-initiated-payment-required-param": {
+        "type": "string",
+        "enum": [
+          "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
+        ]
+      },
+      "req-param-cust-present-initiator": {
+        "type": "string",
+        "enum": [
+          "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
+        ]
+      },
+      "item-category-not-supported-payment-source": {
+        "type": "string",
+        "enum": [
+          "ITEM_CATEGORY_NOT_SUPPORTED_BY_PAYMENT_SOURCE"
+        ]
+      },
+      "payment-source-does-not-support-item-category": {
+        "type": "string",
+        "enum": [
+          "The provided payment source does not support provided item category."
+        ]
+      },
+      "payment-source-info-cannot-be-verified1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_INFO_CANNOT_BE_VERIFIED"
+        ]
+      },
+      "unverified-payment-source-and-address-combination": {
+        "type": "string",
+        "enum": [
+          "The combination of the payment_source name, billing address, shipping name and shipping address could not be verified. Please correct this information and try again by creating a new order."
+        ]
+      },
+      "payment-source-declined-by-processor1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_DECLINED_BY_PROCESSOR"
+        ]
+      },
+      "payment-source-declined-by-processor1-description": {
+        "type": "string",
+        "enum": [
+          "The provided payment source is declined by the processor. Please try again with a different payment source by creating a new order."
+        ]
+      },
+      "payment-source-cannot-be-used1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_CANNOT_BE_USED"
+        ]
+      },
+      "payment-source-cannot-be-used1-description": {
+        "type": "string",
+        "enum": [
+          "The provided payment source cannot be used to pay for the order. Please try again with a different payment source by creating a new order."
+        ]
+      },
+      "setup-error-for-bank-issue": {
+        "type": "string",
+        "enum": [
+          "SETUP_ERROR_FOR_BANK"
+        ]
+      },
+      "setup-error-for-bank-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller account setup, for bank payments, is incomplete or incorrect. Please contact your PayPal account manager."
+        ]
+      },
+      "bank-not-supported-for-verification-issue": {
+        "type": "string",
+        "enum": [
+          "BANK_NOT_SUPPORTED_FOR_VERIFICATION"
+        ]
+      },
+      "bank-not-supported-for-verification-description": {
+        "type": "string",
+        "enum": [
+          "Verification for this bank account is not supported."
+        ]
+      },
+      "apple-pay-amount-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "APPLE_PAY_AMOUNT_MISMATCH"
+        ]
+      },
+      "apple-pay-amount-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
+        ]
+      },
+      "one-of-the-parameters-required-issue": {
+        "type": "string",
+        "enum": [
+          "ONE_OF_THE_PARAMETERS_REQUIRED"
+        ]
+      },
+      "one-of-the-parameters-required-description": {
+        "type": "string",
+        "enum": [
+          "One or more field is required to continue with this request."
+        ]
+      },
+      "billing-address-invalid1-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_ADDRESS_INVALID"
+        ]
+      },
+      "billing-address-invalid1-description": {
+        "type": "string",
+        "enum": [
+          "Provided billing address is invalid."
+        ]
+      },
+      "shipping-address-invalid1-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_ADDRESS_INVALID"
+        ]
+      },
+      "shipping-address-invalid1-description": {
+        "type": "string",
+        "enum": [
+          "Provided shipping address is invalid."
+        ]
+      },
+      "order-is-pending-approval-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_IS_PENDING_APPROVAL"
+        ]
+      },
+      "order-is-pending-approval-description": {
+        "type": "string",
+        "enum": [
+          "The order was confirmed and payer action completed but order approval processing from PayPal is pending. No action is needed from Payee or Payer. Please wait until order status changes to 'APPROVED'."
+        ]
+      },
+      "device-data-not-available-issue": {
+        "type": "string",
+        "enum": [
+          "DEVICE_DATA_NOT_AVAILABLE"
+        ]
+      },
+      "device-data-not-available-description": {
+        "type": "string",
+        "enum": [
+          "Device Data is not available for processing this order. The PayPal-Client-Metadata-Id header value sent during `Create Order` api call is either missing or incorrect or there was an error in collecting required data. Please verify if appropriate value for PayPal-Client-Metadata-Id header is being sent during 'Create Order' api call. Please note this error only applies to payment_source.pay_upon_invoice at the moment."
+        ]
+      },
+      "currency-not-supported-for-bank-issue": {
+        "type": "string",
+        "enum": [
+          "CURRENCY_NOT_SUPPORTED_FOR_BANK"
+        ]
+      },
+      "currency-not-supported-for-bank-description": {
+        "type": "string",
+        "enum": [
+          "The payment_source does not support the currency of the Order. For ACH debit, only USD is supported and for SEPA debit, only EUR is supported."
+        ]
+      },
+      "only-one-bank-source-allowed-issue": {
+        "type": "string",
+        "enum": [
+          "ONLY_ONE_BANK_SOURCE_ALLOWED"
+        ]
+      },
+      "only-one-bank-source-allowed-description": {
+        "type": "string",
+        "enum": [
+          "More than one payment method within the bank payment object is not supported."
+        ]
+      },
+      "invalid-iban-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_IBAN"
+        ]
+      },
+      "invalid-iban-description": {
+        "type": "string",
+        "enum": [
+          "IBAN provided is not a valid bank account number."
+        ]
+      },
+      "iban-country-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "IBAN_COUNTRY_NOT_SUPPORTED"
+        ]
+      },
+      "iban-country-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "Country code of issuer bank for the provided IBAN is not supported for SEPA debit payments."
+        ]
+      },
+      "payee-country-not-supported-payment-source": {
+        "type": "string",
+        "enum": [
+          "PAYEE_COUNTRY_NOT_SUPPORTED_FOR_PAYMENT_SOURCE"
+        ]
+      },
+      "payee-country-code-not-supported-payment-source": {
+        "type": "string",
+        "enum": [
+          "Payee country code is not supported by the provided payment source."
+        ]
+      },
+      "card-number-required-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_NUMBER_REQUIRED"
+        ]
+      },
+      "card-number-required-description": {
+        "type": "string",
+        "enum": [
+          "The card number is required when attempting to process payment with card."
+        ]
+      },
+      "card-expiry-required-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_EXPIRY_REQUIRED"
+        ]
+      },
+      "card-expiry-required-description": {
+        "type": "string",
+        "enum": [
+          "The card expiry is required when attempting to process payment with card."
+        ]
+      },
+      "incompatible-parameter-value1-issue": {
+        "type": "string",
+        "enum": [
+          "INCOMPATIBLE_PARAMETER_VALUE"
+        ]
+      },
+      "incompatible-parameter-value1-description": {
+        "type": "string",
+        "enum": [
+          "The value of the field is incompatible/redundant with other fields in the order."
+        ]
+      },
+      "vault-instruction-duplicated1-issue": {
+        "type": "string",
+        "enum": [
+          "VAULT_INSTRUCTION_DUPLICATED"
+        ]
+      },
+      "vault-instruction-duplicated1-description": {
+        "type": "string",
+        "enum": [
+          "Only one vault instruction is allowed. Please use `vault.store_in_vault` to provide vault instruction."
+        ]
+      },
+      "vault-instruction-required1-issue": {
+        "type": "string",
+        "enum": [
+          "VAULT_INSTRUCTION_REQUIRED"
+        ]
+      },
+      "vault-instruction-required1-description": {
+        "type": "string",
+        "enum": [
+          "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
+        ]
+      },
+      "mismatched-vault-id-to-payment-source1-issue": {
+        "type": "string",
+        "enum": [
+          "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
+        ]
+      },
+      "mismatched-vault-id-to-payment-source1-description": {
+        "type": "string",
+        "enum": [
+          "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
+        ]
+      },
+      "not-eligible-for-pnref-processing1-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
+        ]
+      },
+      "not-eligible-for-pnref-processing1-description": {
+        "type": "string",
+        "enum": [
+          "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
+        ]
+      },
+      "not-eligible-paypal-transaction-id-processing": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
+        ]
+      },
+      "paypal-transaction-id-processing-permission-error": {
+        "type": "string",
+        "enum": [
+          "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
+        ]
+      },
+      "paypal-transaction-id-not-found1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_TRANSACTION_ID_NOT_FOUND"
+        ]
+      },
+      "paypal-transaction-id-not-found1-description": {
+        "type": "string",
+        "enum": [
+          "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
+        ]
+      },
+      "pnref-not-found1-issue": {
+        "type": "string",
+        "enum": [
+          "PNREF_NOT_FOUND"
+        ]
+      },
+      "pnref-not-found1-description": {
+        "type": "string",
+        "enum": [
+          "Specified `pnref` was not found. Verify the value and try the request again."
+        ]
+      },
+      "invalid-security-code-length1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_SECURITY_CODE_LENGTH"
+        ]
+      },
+      "invalid-security-code-length1-description": {
+        "type": "string",
+        "enum": [
+          "The security_code length is invalid for the specified card brand."
+        ]
+      },
+      "not-enabled-to-vault-payment-source1-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE"
+        ]
+      },
+      "not-enabled-to-vault-payment-source1-description": {
+        "type": "string",
+        "enum": [
+          "The API caller or the merchant on whose behalf the API call is initiated is not allowed to vault the given source. Please contact PayPal customer support for assistance."
+        ]
+      },
+      "cryptogram-required3-issue": {
+        "type": "string",
+        "enum": [
+          "CRYPTOGRAM_REQUIRED"
+        ]
+      },
+      "cryptogram-required3-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is required if authentication method is CRYPTOGRAM 3DS."
+        ]
+      },
+      "emv-data-required1-issue": {
+        "type": "string",
+        "enum": [
+          "EMV_DATA_REQUIRED"
+        ]
+      },
+      "emv-data-required1-description": {
+        "type": "string",
+        "enum": [
+          "EMV Data is required if authentication method is EMV."
+        ]
+      },
+      "alias-declined-by-processor1-issue": {
+        "type": "string",
+        "enum": [
+          "ALIAS_DECLINED_BY_PROCESSOR"
+        ]
+      },
+      "alias-declined-by-processor1-description": {
+        "type": "string",
+        "enum": [
+          "The provided alias was declined by the processor. Please create a new order with a different alias_key and/or alias_label and try again."
+        ]
+      },
+      "blik-one-click-missing-required-parameter1-issue": {
+        "type": "string",
+        "enum": [
+          "BLIK_ONE_CLICK_MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "blik-one-click-first-transaction-params": {
+        "type": "string",
+        "enum": [
+          "Blik's one_click flow requires one_click.auth_code and one_click.alias_label parameters for the buyer's first transaction. For all subsequent transactions,only the one_click.alias_key parameter is required."
+        ]
+      },
+      "invalid-country-code1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_COUNTRY_CODE"
+        ]
+      },
+      "invalid-country-code1-description": {
+        "type": "string",
+        "enum": [
+          "Country code is invalid. Please refer to https://developer.paypal.com/api/rest/reference/country-codes/ for a list of supported country codes."
+        ]
+      },
+      "invalid-parameter-value3-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value3-description": {
+        "type": "string",
+        "enum": [
+          "A parameter value is not valid."
+        ]
+      },
+      "missing-required-parameter3-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter3-description": {
+        "type": "string",
+        "enum": [
+          "A required field / parameter is missing"
+        ]
+      },
+      "invalid-string-length3-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length3-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long"
+        ]
+      },
+      "invalid-parameter-syntax3-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_SYNTAX"
+        ]
+      },
+      "invalid-parameter-syntax3-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field does not conform to the expected format."
+        ]
+      },
+      "malformed-request-json3-issue": {
+        "type": "string",
+        "enum": [
+          "MALFORMED_REQUEST_JSON"
+        ]
+      },
+      "malformed-request-json3-description": {
+        "type": "string",
+        "enum": [
+          "The request JSON is not well formed."
+        ]
+      },
+      "not-eligible-for-token-processing-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING"
+        ]
+      },
+      "not-eligible-for-token-processing-description": {
+        "type": "string",
+        "enum": [
+          "API caller is not enabled to process payments with the specified type of token. Please contact customer support to request permissions to process transactions with this type of token."
+        ]
+      },
+      "permission-denied1-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED"
+        ]
+      },
+      "permission-denied1-description": {
+        "type": "string",
+        "enum": [
+          "You do not have permission to access or perform operations on this resource."
+        ]
+      },
+      "permission-denied-for-donation-items-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED_FOR_DONATION_ITEMS"
+        ]
+      },
+      "permission-denied-for-donation-items-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller or Payee have not been granted appropriate permissions to send 'items.category' as 'DONATION'. Please speak to your account manager if you want to process these type of items."
+        ]
+      },
+      "action-does-not-match-intent-issue": {
+        "type": "string",
+        "enum": [
+          "ACTION_DOES_NOT_MATCH_INTENT"
+        ]
+      },
+      "action-does-not-match-intent-description": {
+        "type": "string",
+        "enum": [
+          "Order was created with an intent to 'CAPTURE'. Please use v2/checkout/orders/order_id/capture to complete the transaction or alternately Create an order with an intent of 'AUTHORIZE'."
+        ]
+      },
+      "agreement-already-cancelled1-issue": {
+        "type": "string",
+        "enum": [
+          "AGREEMENT_ALREADY_CANCELLED"
+        ]
+      },
+      "agreement-already-cancelled1-description": {
+        "type": "string",
+        "enum": [
+          "The requested agreement is already canceled."
+        ]
+      },
+      "billing-agreement-not-found1-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_AGREEMENT_NOT_FOUND"
+        ]
+      },
+      "billing-agreement-not-found1-description": {
+        "type": "string",
+        "enum": [
+          "The requested Billing Agreement token was not found."
+        ]
+      },
+      "missing-previous-reference2-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_PREVIOUS_REFERENCE"
+        ]
+      },
+      "missing-previous-reference2-description": {
+        "type": "string",
+        "enum": [
+          "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
+        ]
+      },
+      "missing-cryptogram2-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_CRYPTOGRAM"
+        ]
+      },
+      "missing-cryptogram2-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is mandatory for any customer initiated network token transactions."
+        ]
+      },
+      "card-brand-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_BRAND_NOT_SUPPORTED"
+        ]
+      },
+      "card-brand-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "Processing of this card brand is not supported. Please use another card to continue with this transaction."
+        ]
+      },
+      "declined-due-to-related-txn-issue": {
+        "type": "string",
+        "enum": [
+          "DECLINED_DUE_TO_RELATED_TXN"
+        ]
+      },
+      "declined-due-to-related-txn-description": {
+        "type": "string",
+        "enum": [
+          "One or more transactions in this Order did not succeed. Since this Order is being processed as an All or None Order, if one or more transactions in this Order do not succeed, then all purchase units are marked declined and will not be processed."
+        ]
+      },
+      "domestic-transaction-required1-issue": {
+        "type": "string",
+        "enum": [
+          "DOMESTIC_TRANSACTION_REQUIRED"
+        ]
+      },
+      "domestic-transaction-required1-description": {
+        "type": "string",
+        "enum": [
+          "This transaction requires the payee and payer to be resident in the same country, a domestic transaction is required to create this payment."
+        ]
+      },
+      "duplicate-invoice-id1-issue": {
+        "type": "string",
+        "enum": [
+          "DUPLICATE_INVOICE_ID"
+        ]
+      },
+      "duplicate-invoice-id1-description": {
+        "type": "string",
+        "enum": [
+          "Duplicate Invoice ID detected. To avoid a potential duplicate transaction your account setting requires that Invoice Id be unique for each transaction."
+        ]
+      },
+      "order-not-approved-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_NOT_APPROVED"
+        ]
+      },
+      "order-not-approved-description": {
+        "type": "string",
+        "enum": [
+          "Payer has not yet approved the Order for payment. Please redirect the payer to the 'rel':'approve' url returned as part of the HATEOAS links within the Create Order call."
+        ]
+      },
+      "max-number-of-payment-attempts-exceeded1-issue": {
+        "type": "string",
+        "enum": [
+          "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED"
+        ]
+      },
+      "exceeded-max-payment-attempts-error": {
+        "type": "string",
+        "enum": [
+          "You have exceeded the maximum number of payment attempts."
+        ]
+      },
+      "payee-blocked-transaction1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_BLOCKED_TRANSACTION"
+        ]
+      },
+      "payee-blocked-transaction1-description": {
+        "type": "string",
+        "enum": [
+          "The Fraud settings for this seller are such that this payment cannot be executed."
+        ]
+      },
+      "payee-fx-rate-id-expired2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_FX_RATE_ID_EXPIRED"
+        ]
+      },
+      "payee-fx-rate-id-expired2-description": {
+        "type": "string",
+        "enum": [
+          "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
+        ]
+      },
+      "unsupported-intent-for-payment-source-issue": {
+        "type": "string",
+        "enum": [
+          "UNSUPPORTED_INTENT_FOR_PAYMENT_SOURCE"
+        ]
+      },
+      "unsupported-intent-for-payment-source-description": {
+        "type": "string",
+        "enum": [
+          "`intent=AUTHORIZE` is not supported for the specified payment_source. Only `intent=CAPTURE` is supported."
+        ]
+      },
+      "payer-account-locked-or-closed1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_LOCKED_OR_CLOSED"
+        ]
+      },
+      "payer-account-locked-or-closed1-description": {
+        "type": "string",
+        "enum": [
+          "The payer account cannot be used for this transaction."
+        ]
+      },
+      "payer-account-restricted1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payer-account-restricted1-description": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payer-cannot-pay1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_CANNOT_PAY"
+        ]
+      },
+      "payer-cannot-pay1-description": {
+        "type": "string",
+        "enum": [
+          "Payer cannot pay for this transaction. Please contact the payer to find other ways to pay for this transaction."
+        ]
+      },
+      "paypal-transaction-id-expired-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_TRANSACTION_ID_EXPIRED"
+        ]
+      },
+      "paypal-transaction-id-expired-description": {
+        "type": "string",
+        "enum": [
+          "Specified `paypal_transaction_id` has expired. PayPal transaction ID expires 4 years after the date of the initial transaction."
+        ]
+      },
+      "pnref-expired-issue": {
+        "type": "string",
+        "enum": [
+          "PNREF_EXPIRED"
+        ]
+      },
+      "pnref-expired-description": {
+        "type": "string",
+        "enum": [
+          "Specified `pnref` has expired. PNREF expires 15 months after the date of the initial transaction."
+        ]
+      },
+      "referenced-card-expired-issue": {
+        "type": "string",
+        "enum": [
+          "REFERENCED_CARD_EXPIRED"
+        ]
+      },
+      "referenced-card-expired-description": {
+        "type": "string",
+        "enum": [
+          "The card underlying the token has expired and hence cannot be used to process a payment."
+        ]
+      },
+      "token-expired2-issue": {
+        "type": "string",
+        "enum": [
+          "TOKEN_EXPIRED"
+        ]
+      },
+      "token-expired2-description": {
+        "type": "string",
+        "enum": [
+          "The token is expired and cannot be used for payment."
+        ]
+      },
+      "token-id-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "TOKEN_ID_NOT_FOUND"
+        ]
+      },
+      "token-id-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Specified token was not found. Verify the token and try the request again."
+        ]
+      },
+      "transaction-limit-exceeded1-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_LIMIT_EXCEEDED"
+        ]
+      },
+      "transaction-limit-exceeded1-description": {
+        "type": "string",
+        "enum": [
+          "Total payment amount exceeded transaction limit."
+        ]
+      },
+      "transaction-receiving-limit-exceeded1-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_RECEIVING_LIMIT_EXCEEDED"
+        ]
+      },
+      "transaction-receiving-limit-exceeded1-description": {
+        "type": "string",
+        "enum": [
+          "The transaction exceeds the receiver's receiving limit."
+        ]
+      },
+      "transaction-refused1-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_REFUSED"
+        ]
+      },
+      "transaction-refused1-description": {
+        "type": "string",
+        "enum": [
+          "The request was refused."
+        ]
+      },
+      "order-already-authorized1-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_ALREADY_AUTHORIZED"
+        ]
+      },
+      "order-already-authorized1-description": {
+        "type": "string",
+        "enum": [
+          "Order already authorized.If 'intent=AUTHORIZE' only one authorization per order is allowed."
+        ]
+      },
+      "auth-capture-not-enabled1-issue": {
+        "type": "string",
+        "enum": [
+          "AUTH_CAPTURE_NOT_ENABLED"
+        ]
+      },
+      "auth-capture-not-enabled1-description": {
+        "type": "string",
+        "enum": [
+          "Authorization and Capture feature is not enabled for the merchant. Make sure that the recipient of the funds is a verified business account."
+        ]
+      },
+      "amount-cannot-be-specified-issue": {
+        "type": "string",
+        "enum": [
+          "AMOUNT_CANNOT_BE_SPECIFIED"
+        ]
+      },
+      "amount-cannot-be-specified-description": {
+        "type": "string",
+        "enum": [
+          "An authorization amount can only be specified if an Order has been saved by calling /v2/checkout/orders/{order_id}/save.  Please save the order and try again."
+        ]
+      },
+      "authorization-amount-exceeded-issue": {
+        "type": "string",
+        "enum": [
+          "AUTHORIZATION_AMOUNT_EXCEEDED"
+        ]
+      },
+      "authorization-amount-exceeded-description": {
+        "type": "string",
+        "enum": [
+          "Authorization amount specified exceeded allowable limit. Specify a different amount and try the request again. Alternately, contact Customer Support to increase your limits. Local regulations (e.g. in PSD2 countries) prohibit overages above the amount authorized by the payer."
+        ]
+      },
+      "authorization-currency-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "AUTHORIZATION_CURRENCY_MISMATCH"
+        ]
+      },
+      "authorization-currency-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "The currency of the authorization should be same as that in which the Order was created and approved by the Payer. Please check the 'currency_code' and try again."
+        ]
+      },
+      "max-authorization-count-exceeded-issue": {
+        "type": "string",
+        "enum": [
+          "MAX_AUTHORIZATION_COUNT_EXCEEDED"
+        ]
+      },
+      "max-authorization-count-exceeded-description": {
+        "type": "string",
+        "enum": [
+          "Maximum number of authorization allowed for the order is reached. Please contact Customer Support if you need to increase your limit."
+        ]
+      },
+      "order-completed-or-voided-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_COMPLETED_OR_VOIDED"
+        ]
+      },
+      "order-completed-or-voided-description": {
+        "type": "string",
+        "enum": [
+          "Order is voided or completed and hence cannot be authorized."
+        ]
+      },
+      "order-expired-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_EXPIRED"
+        ]
+      },
+      "order-expired-description": {
+        "type": "string",
+        "enum": [
+          "Order is expired and hence cannot be authorized. Please contact Customer Support if you need to increase your order validity period."
+        ]
+      },
+      "invalid-pickup-address-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PICKUP_ADDRESS"
+        ]
+      },
+      "invalid-pickup-address-description": {
+        "type": "string",
+        "enum": [
+          "If the 'shipping_option.type' is set as 'PICKUP' then the 'shipping_detail.name.full_name' should start with 'S2S' meaning Ship To Store. Example: 'S2S My Store'."
+        ]
+      },
+      "shipping-address-invalid2-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_ADDRESS_INVALID"
+        ]
+      },
+      "shipping-address-invalid2-description": {
+        "type": "string",
+        "enum": [
+          "Provided shipping address is invalid."
+        ]
+      },
+      "payment-type-not-supported-for-intent-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_TYPE_NOT_SUPPORTED_FOR_INTENT"
+        ]
+      },
+      "payment-type-not-supported-for-intent-description": {
+        "type": "string",
+        "enum": [
+          "Provided payment type not supported for order intent. Payment authorizations are supported only for order with `intent=AUTHORIZE` and payment captures are supported only for order with `intent=CAPTURE`."
+        ]
+      },
+      "billing-agreement-id-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_AGREEMENT_ID_MISMATCH"
+        ]
+      },
+      "billing-agreement-id-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "Billing Agreement ID must exactly match the Billing Agreement ID that was provided during order creation."
+        ]
+      },
+      "preferred-payment-source-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "PREFERRED_PAYMENT_SOURCE_MISMATCH"
+        ]
+      },
+      "preferred-payment-source-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "Payment Source must exactly match the Preferred Payment Source that was provided during order creation."
+        ]
+      },
+      "incompatible-parameter-value2-issue": {
+        "type": "string",
+        "enum": [
+          "INCOMPATIBLE_PARAMETER_VALUE"
+        ]
+      },
+      "incompatible-parameter-value2-description": {
+        "type": "string",
+        "enum": [
+          "The value of the field is incompatible/redundant with other fields in the order."
+        ]
+      },
+      "invalid-previous-transaction-reference1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PREVIOUS_TRANSACTION_REFERENCE"
+        ]
+      },
+      "invalid-previous-transaction-reference-error": {
+        "type": "string",
+        "enum": [
+          "The authorization or capture referenced by `previous_transaction_reference` is not valid. This could be either because the previous_transaction_reference is not found or doesn't belong to the payee. Please use a valid `previous_transaction_reference`."
+        ]
+      },
+      "previous-transaction-reference-chargeback-issue": {
+        "type": "string",
+        "enum": [
+          "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK"
+        ]
+      },
+      "capture-with-chargeback-not-usable-desc": {
+        "type": "string",
+        "enum": [
+          "The capture referenced by `previous_transaction_reference` has a chargeback and hence cannot be used for this order. Please use a `previous_transaction_reference` which does not have a chargeback."
+        ]
+      },
+      "previous-transaction-reference-voided1-issue": {
+        "type": "string",
+        "enum": [
+          "PREVIOUS_TRANSACTION_REFERENCE_VOIDED"
+        ]
+      },
+      "previous-transaction-reference-voided1-description": {
+        "type": "string",
+        "enum": [
+          "The status of authorization referenced by `previous_transaction_reference` is `VOIDED` and hence cannot be used for this order. Please use a `previous_transaction_reference` whose status is not `VOIDED`."
+        ]
+      },
+      "payment-source-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_MISMATCH"
+        ]
+      },
+      "payment-source-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "The `payment_source` in the request must match the `payment_source` used for the authorization or capture referenced by `previous_transaction_reference`. Please use `previous_transaction_reference` whose `payment_source` matches with the `payment_source` specified in the order."
+        ]
+      },
+      "merchant-initiated-with-security-code1-issue": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_SECURITY_CODE"
+        ]
+      },
+      "merchant-initiated-with-security-code1-description": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if `payment_source.card.security_code` is present in the order. `security_code` can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with `security_code` is the order."
+        ]
+      },
+      "merchant-initiated-auth-with-results": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS"
+        ]
+      },
+      "err-merch-init-auth-results-3ds-invalid": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if 3D-Secure authentication results are present in the order. 3D-Secure authentication results can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with 3D-Secure authentication results is the order."
+        ]
+      },
+      "merchant-initiated-multiple-purchase-units-issue": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS"
+        ]
+      },
+      "err-merch-init-multi-units-not-supported": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if more than one purchase_unit is present in the Order. Merchant initiated payments are not supported from orders with more than one purchase_unit. Please retry the request with multiple Order requests (one for each purchase_unit)."
+        ]
+      },
+      "return-url-required1-issue": {
+        "type": "string",
+        "enum": [
+          "RETURN_URL_REQUIRED"
+        ]
+      },
+      "return-url-required1-description": {
+        "type": "string",
+        "enum": [
+          "The return url is required when attempting to vault this source."
+        ]
+      },
+      "cancel-url-required1-issue": {
+        "type": "string",
+        "enum": [
+          "CANCEL_URL_REQUIRED"
+        ]
+      },
+      "cancel-url-required1-description": {
+        "type": "string",
+        "enum": [
+          "The cancel url is required when attempting to vault this source."
+        ]
+      },
+      "payer-action-required-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACTION_REQUIRED"
+        ]
+      },
+      "payer-action-required-description": {
+        "type": "string",
+        "enum": [
+          "Transaction cannot complete successfully, instruct the buyer to return to PayPal."
+        ]
+      },
+      "apple-pay-amount-mismatch2-issue": {
+        "type": "string",
+        "enum": [
+          "APPLE_PAY_AMOUNT_MISMATCH"
+        ]
+      },
+      "apple-pay-amount-mismatch2-description": {
+        "type": "string",
+        "enum": [
+          "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
+        ]
+      },
+      "card-number-required1-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_NUMBER_REQUIRED"
+        ]
+      },
+      "card-number-required1-description": {
+        "type": "string",
+        "enum": [
+          "The card number is required when attempting to process payment with card."
+        ]
+      },
+      "card-expiry-required1-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_EXPIRY_REQUIRED"
+        ]
+      },
+      "card-expiry-required1-description": {
+        "type": "string",
+        "enum": [
+          "The card expiry is required when attempting to process payment with card."
+        ]
+      },
+      "vault-instruction-required2-issue": {
+        "type": "string",
+        "enum": [
+          "VAULT_INSTRUCTION_REQUIRED"
+        ]
+      },
+      "vault-instruction-required2-description": {
+        "type": "string",
+        "enum": [
+          "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
+        ]
+      },
+      "mismatched-vault-id-to-payment-source2-issue": {
+        "type": "string",
+        "enum": [
+          "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
+        ]
+      },
+      "mismatched-vault-id-to-payment-source2-description": {
+        "type": "string",
+        "enum": [
+          "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
+        ]
+      },
+      "order-cannot-be-saved-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_CANNOT_BE_SAVED"
+        ]
+      },
+      "order-cannot-be-saved-description": {
+        "type": "string",
+        "enum": [
+          "The option to save an order is only available if the `intent` is AUTHORIZE and `processing_instruction` uses one of the `ORDER_SAVED` options. For example, `intent`=AUTHORIZE, `processing_instruction`=ORDER_SAVED_EXPLICITLY. Please change the intent and/or processing_instruction` and try again."
+        ]
+      },
+      "save-order-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "SAVE_ORDER_NOT_SUPPORTED"
+        ]
+      },
+      "save-order-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "The API caller account is setup in a way that does not allow it to be used for saving the order. This functionality is not available for PayPal Commerce Platform for Platforms & Marketplaces."
+        ]
+      },
+      "not-eligible-for-pnref-processing2-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
+        ]
+      },
+      "not-eligible-for-pnref-processing2-description": {
+        "type": "string",
+        "enum": [
+          "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
+        ]
+      },
+      "not-eligible-paypal-tx-id-processing": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
+        ]
+      },
+      "paypal-tx-id-processing-permission-needed": {
+        "type": "string",
+        "enum": [
+          "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
+        ]
+      },
+      "paypal-transaction-id-not-found2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_TRANSACTION_ID_NOT_FOUND"
+        ]
+      },
+      "paypal-transaction-id-not-found2-description": {
+        "type": "string",
+        "enum": [
+          "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
+        ]
+      },
+      "pnref-not-found2-issue": {
+        "type": "string",
+        "enum": [
+          "PNREF_NOT_FOUND"
+        ]
+      },
+      "pnref-not-found2-description": {
+        "type": "string",
+        "enum": [
+          "Specified `pnref` was not found. Verify the value and try the request again."
+        ]
+      },
+      "invalid-security-code-length2-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_SECURITY_CODE_LENGTH"
+        ]
+      },
+      "invalid-security-code-length2-description": {
+        "type": "string",
+        "enum": [
+          "The security_code length is invalid for the specified card brand."
+        ]
+      },
+      "required-param-for-cust-initiated-payment": {
+        "type": "string",
+        "enum": [
+          "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
+        ]
+      },
+      "req-param-cust-present-initiator-merch-desc": {
+        "type": "string",
+        "enum": [
+          "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
+        ]
+      },
+      "invalid-parameter-value4-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value4-description": {
+        "type": "string",
+        "enum": [
+          "A parameter value is not valid."
+        ]
+      },
+      "missing-required-parameter4-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter4-description": {
+        "type": "string",
+        "enum": [
+          "A required field / parameter is missing"
+        ]
+      },
+      "invalid-string-length4-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length4-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long"
+        ]
+      },
+      "invalid-parameter-syntax4-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_SYNTAX"
+        ]
+      },
+      "invalid-parameter-syntax4-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field does not conform to the expected format."
+        ]
+      },
+      "malformed-request-json4-issue": {
+        "type": "string",
+        "enum": [
+          "MALFORMED_REQUEST_JSON"
+        ]
+      },
+      "malformed-request-json4-description": {
+        "type": "string",
+        "enum": [
+          "The request JSON is not well formed."
+        ]
+      },
+      "consent-needed-issue": {
+        "type": "string",
+        "enum": [
+          "CONSENT_NEEDED"
+        ]
+      },
+      "consent-needed-description": {
+        "type": "string",
+        "enum": [
+          "CONSENT_NEEDED"
+        ]
+      },
+      "not-eligible-for-token-processing1-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_TOKEN_PROCESSING"
+        ]
+      },
+      "not-eligible-for-token-processing1-description": {
+        "type": "string",
+        "enum": [
+          "API caller is not enabled to process payments with the specified type of token. Please contact customer support to request permissions to process transactions with this type of token."
+        ]
+      },
+      "permission-denied2-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED"
+        ]
+      },
+      "permission-denied2-description": {
+        "type": "string",
+        "enum": [
+          "You do not have permission to access or perform operations on this resource."
+        ]
+      },
+      "permission-denied-for-donation-items1-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED_FOR_DONATION_ITEMS"
+        ]
+      },
+      "permission-denied-for-donation-items1-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller or Payee have not been granted appropriate permissions to send 'items.category' as 'DONATION'. Please speak to your account manager if you want to process these type of items."
+        ]
+      },
+      "agreement-already-cancelled2-issue": {
+        "type": "string",
+        "enum": [
+          "AGREEMENT_ALREADY_CANCELLED"
+        ]
+      },
+      "agreement-already-cancelled2-description": {
+        "type": "string",
+        "enum": [
+          "The requested agreement is already canceled."
+        ]
+      },
+      "billing-agreement-not-found2-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_AGREEMENT_NOT_FOUND"
+        ]
+      },
+      "billing-agreement-not-found2-description": {
+        "type": "string",
+        "enum": [
+          "The requested Billing Agreement token was not found."
+        ]
+      },
+      "declined-due-to-related-txn1-issue": {
+        "type": "string",
+        "enum": [
+          "DECLINED_DUE_TO_RELATED_TXN"
+        ]
+      },
+      "declined-due-to-related-txn1-description": {
+        "type": "string",
+        "enum": [
+          "One or more transactions in this Order did not succeed. Since this Order is being processed as an All or None Order, if one or more transactions in this Order do not succeed, then all purchase units are marked declined and will not be processed."
+        ]
+      },
+      "missing-previous-reference3-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_PREVIOUS_REFERENCE"
+        ]
+      },
+      "missing-previous-reference3-description": {
+        "type": "string",
+        "enum": [
+          "For Merchant initiated network token transactions, either the payment_source.card.stored_credential.previous_network_transaction_reference or payment_source.card.stored_credential.previous_transaction_reference must be included in the request."
+        ]
+      },
+      "missing-cryptogram3-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_CRYPTOGRAM"
+        ]
+      },
+      "missing-cryptogram3-description": {
+        "type": "string",
+        "enum": [
+          "Cryptogram is mandatory for any customer initiated network token transactions."
+        ]
+      },
+      "card-brand-not-supported1-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_BRAND_NOT_SUPPORTED"
+        ]
+      },
+      "card-brand-not-supported1-description": {
+        "type": "string",
+        "enum": [
+          "Processing of this card brand is not supported. Please use another card to continue with this transaction."
+        ]
+      },
+      "compliance-violation1-issue": {
+        "type": "string",
+        "enum": [
+          "COMPLIANCE_VIOLATION"
+        ]
+      },
+      "compliance-violation1-description": {
+        "type": "string",
+        "enum": [
+          "Transaction is declined due to compliance violation."
+        ]
+      },
+      "domestic-transaction-required2-issue": {
+        "type": "string",
+        "enum": [
+          "DOMESTIC_TRANSACTION_REQUIRED"
+        ]
+      },
+      "domestic-transaction-required2-description": {
+        "type": "string",
+        "enum": [
+          "This transaction requires the payee and payer to be resident in the same country, a domestic transaction is required to create this payment."
+        ]
+      },
+      "duplicate-invoice-id2-issue": {
+        "type": "string",
+        "enum": [
+          "DUPLICATE_INVOICE_ID"
+        ]
+      },
+      "duplicate-invoice-id2-description": {
+        "type": "string",
+        "enum": [
+          "Duplicate Invoice ID detected. To avoid a potential duplicate transaction your account setting requires that Invoice Id be unique for each transaction."
+        ]
+      },
+      "instrument-declined1-issue": {
+        "type": "string",
+        "enum": [
+          "INSTRUMENT_DECLINED"
+        ]
+      },
+      "instrument-declined1-description": {
+        "type": "string",
+        "enum": [
+          "The instrument presented  was either declined by the processor or bank, or it can't be used for this payment."
+        ]
+      },
+      "order-not-approved1-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_NOT_APPROVED"
+        ]
+      },
+      "order-not-approved1-description": {
+        "type": "string",
+        "enum": [
+          "Payer has not yet approved the Order for payment. Please redirect the payer to the 'rel':'approve' url returned as part of the HATEOAS links within the Create Order call or provide a valid `payment_source` in the request."
+        ]
+      },
+      "max-number-of-payment-attempts-exceeded2-issue": {
+        "type": "string",
+        "enum": [
+          "MAX_NUMBER_OF_PAYMENT_ATTEMPTS_EXCEEDED"
+        ]
+      },
+      "exceeded-max-payment-attempts-desc": {
+        "type": "string",
+        "enum": [
+          "You have exceeded the maximum number of payment attempts."
+        ]
+      },
+      "payee-blocked-transaction2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_BLOCKED_TRANSACTION"
+        ]
+      },
+      "payee-blocked-transaction2-description": {
+        "type": "string",
+        "enum": [
+          "The Fraud settings for this seller are such that this payment cannot be executed."
+        ]
+      },
+      "payee-fx-rate-id-expired3-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_FX_RATE_ID_EXPIRED"
+        ]
+      },
+      "payee-fx-rate-id-expired3-description": {
+        "type": "string",
+        "enum": [
+          "The specified FX Rate ID has expired. Please specify a different FX Rate Id and try the request again. Alternately, remove the FX Rate ID to process the request using the default exchange rate."
+        ]
+      },
+      "payer-account-locked-or-closed2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_LOCKED_OR_CLOSED"
+        ]
+      },
+      "payer-account-locked-or-closed2-description": {
+        "type": "string",
+        "enum": [
+          "The payer account cannot be used for this transaction."
+        ]
+      },
+      "payer-account-restricted2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payer-account-restricted2-description": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACCOUNT_RESTRICTED"
+        ]
+      },
+      "payer-cannot-pay2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_CANNOT_PAY"
+        ]
+      },
+      "payer-cannot-pay2-description": {
+        "type": "string",
+        "enum": [
+          "Payer cannot pay for this transaction. Please contact the payer to find other ways to pay for this transaction."
+        ]
+      },
+      "paypal-transaction-id-expired1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_TRANSACTION_ID_EXPIRED"
+        ]
+      },
+      "paypal-transaction-id-expired1-description": {
+        "type": "string",
+        "enum": [
+          "Specified `paypal_transaction_id` has expired. PayPal transaction ID expires 4 years after the date of the initial transaction."
+        ]
+      },
+      "pnref-expired1-issue": {
+        "type": "string",
+        "enum": [
+          "PNREF_EXPIRED"
+        ]
+      },
+      "pnref-expired1-description": {
+        "type": "string",
+        "enum": [
+          "Specified `pnref` has expired. PNREF expires 15 months after the date of the initial transaction."
+        ]
+      },
+      "referenced-card-expired1-issue": {
+        "type": "string",
+        "enum": [
+          "REFERENCED_CARD_EXPIRED"
+        ]
+      },
+      "referenced-card-expired1-description": {
+        "type": "string",
+        "enum": [
+          "The card underlying the token has expired and hence cannot be used to process a payment."
+        ]
+      },
+      "token-id-not-found1-issue": {
+        "type": "string",
+        "enum": [
+          "TOKEN_ID_NOT_FOUND"
+        ]
+      },
+      "token-id-not-found1-description": {
+        "type": "string",
+        "enum": [
+          "Specified token was not found. Verify the token and try the request again."
+        ]
+      },
+      "transaction-limit-exceeded2-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_LIMIT_EXCEEDED"
+        ]
+      },
+      "transaction-limit-exceeded2-description": {
+        "type": "string",
+        "enum": [
+          "Total payment amount exceeded transaction limit."
+        ]
+      },
+      "transaction-receiving-limit-exceeded2-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_RECEIVING_LIMIT_EXCEEDED"
+        ]
+      },
+      "transaction-receiving-limit-exceeded2-description": {
+        "type": "string",
+        "enum": [
+          "The transaction exceeds the receiver's receiving limit."
+        ]
+      },
+      "transaction-refused2-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_REFUSED"
+        ]
+      },
+      "transaction-refused2-description": {
+        "type": "string",
+        "enum": [
+          "The request was refused."
+        ]
+      },
+      "redirect-payer-for-alternate-funding-issue": {
+        "type": "string",
+        "enum": [
+          "REDIRECT_PAYER_FOR_ALTERNATE_FUNDING"
+        ]
+      },
+      "redirect-payer-for-alternate-funding-description": {
+        "type": "string",
+        "enum": [
+          "Transaction failed. Redirect the payer to select another funding source."
+        ]
+      },
+      "order-already-captured1-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_ALREADY_CAPTURED"
+        ]
+      },
+      "order-already-captured1-description": {
+        "type": "string",
+        "enum": [
+          "Order already captured.If 'intent=CAPTURE' only one capture per order is allowed."
+        ]
+      },
+      "transaction-blocked-by-payee1-issue": {
+        "type": "string",
+        "enum": [
+          "TRANSACTION_BLOCKED_BY_PAYEE"
+        ]
+      },
+      "transaction-blocked-by-payee1-description": {
+        "type": "string",
+        "enum": [
+          "Transaction blocked by Payee’s Fraud Protection settings."
+        ]
+      },
+      "auth-capture-not-enabled2-issue": {
+        "type": "string",
+        "enum": [
+          "AUTH_CAPTURE_NOT_ENABLED"
+        ]
+      },
+      "auth-capture-not-enabled2-description": {
+        "type": "string",
+        "enum": [
+          "Authorization and Capture feature is not enabled for the merchant. Make sure that the recipient of the funds is a verified business account."
+        ]
+      },
+      "not-enabled-for-bank-processing-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ENABLED_FOR_BANK_PROCESSING"
+        ]
+      },
+      "not-enabled-for-bank-processing-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller account is not setup to be able to process bank payments. Please contact your PayPal account manager."
+        ]
+      },
+      "payee-not-enabled-for-bank-processing-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_NOT_ENABLED_FOR_BANK_PROCESSING"
+        ]
+      },
+      "payee-not-enabled-for-bank-processing-description": {
+        "type": "string",
+        "enum": [
+          "Payee account is not setup to be able to process bank payments. Please contact your PayPal account manager."
+        ]
+      },
+      "payee-not-enabled-for-card-processing-issue": {
+        "type": "string",
+        "enum": [
+          "PAYEE_NOT_ENABLED_FOR_CARD_PROCESSING"
+        ]
+      },
+      "payee-not-enabled-for-card-processing-description": {
+        "type": "string",
+        "enum": [
+          "Payee account is not setup to be able to process card payments. Please contact PayPal customer support."
+        ]
+      },
+      "invalid-pickup-address1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PICKUP_ADDRESS"
+        ]
+      },
+      "invalid-pickup-address1-description": {
+        "type": "string",
+        "enum": [
+          "If the 'shipping_option.type' is set as 'PICKUP' then the 'shipping_detail.name.full_name' should start with 'S2S' meaning Ship To Store. Example: 'S2S My Store'."
+        ]
+      },
+      "shipping-address-invalid3-issue": {
+        "type": "string",
+        "enum": [
+          "SHIPPING_ADDRESS_INVALID"
+        ]
+      },
+      "shipping-address-invalid3-description": {
+        "type": "string",
+        "enum": [
+          "Provided shipping address is invalid."
+        ]
+      },
+      "payment-source-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_NOT_SUPPORTED"
+        ]
+      },
+      "payment-source-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "The payer selected method of payment is not supported when multiple purchase units are specified for an Order."
+        ]
+      },
+      "order-completion-in-progress-issue": {
+        "type": "string",
+        "enum": [
+          "ORDER_COMPLETION_IN_PROGRESS"
+        ]
+      },
+      "order-completion-in-progress-description": {
+        "type": "string",
+        "enum": [
+          "The order was created with processing_instruction of ORDER_COMPLETE_ON_PAYMENT_APPROVAL. The customer has approved the payment and PayPal is still in the process of capturing the order on your behalf as instructed. Please try your request again."
+        ]
+      },
+      "billing-agreement-id-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "BILLING_AGREEMENT_ID_MISMATCH"
+        ]
+      },
+      "billing-agreement-id-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "Billing Agreement ID must exactly match the Billing Agreement ID that was provided during order creation."
+        ]
+      },
+      "preferred-payment-source-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "PREFERRED_PAYMENT_SOURCE_MISMATCH"
+        ]
+      },
+      "preferred-payment-source-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "Payment Source must exactly match the Preferred Payment Source that was provided during order creation."
+        ]
+      },
+      "incompatible-parameter-value3-issue": {
+        "type": "string",
+        "enum": [
+          "INCOMPATIBLE_PARAMETER_VALUE"
+        ]
+      },
+      "incompatible-parameter-value3-description": {
+        "type": "string",
+        "enum": [
+          "The value of the field is incompatible/redundant with other fields in the order."
+        ]
+      },
+      "invalid-previous-transaction-reference2-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PREVIOUS_TRANSACTION_REFERENCE"
+        ]
+      },
+      "invalid-previous-tx-reference": {
+        "type": "string",
+        "enum": [
+          "The authorization or capture referenced by `previous_transaction_reference` is not valid. This could be either because the previous_transaction_reference is not found or doesn't belong to the payee. Please use a valid `previous_transaction_reference`."
+        ]
+      },
+      "prev-tx-ref-has-chargeback": {
+        "type": "string",
+        "enum": [
+          "PREVIOUS_TRANSACTION_REFERENCE_HAS_CHARGEBACK"
+        ]
+      },
+      "capture-with-chargeback-not-usable-error": {
+        "type": "string",
+        "enum": [
+          "The capture referenced by `previous_transaction_reference` has a chargeback and hence cannot be used for this order. Please use a `previous_transaction_reference` which does not have a chargeback."
+        ]
+      },
+      "previous-transaction-reference-voided2-issue": {
+        "type": "string",
+        "enum": [
+          "PREVIOUS_TRANSACTION_REFERENCE_VOIDED"
+        ]
+      },
+      "previous-transaction-reference-voided2-description": {
+        "type": "string",
+        "enum": [
+          "The status of authorization referenced by `previous_transaction_reference` is `VOIDED` and hence cannot be used for this order. Please use a `previous_transaction_reference` whose status is not `VOIDED`."
+        ]
+      },
+      "payment-source-mismatch2-issue": {
+        "type": "string",
+        "enum": [
+          "PAYMENT_SOURCE_MISMATCH"
+        ]
+      },
+      "payment-source-mismatch2-description": {
+        "type": "string",
+        "enum": [
+          "The `payment_source` in the request must match the `payment_source` used for the authorization or capture referenced by `previous_transaction_reference`. Please use `previous_transaction_reference` whose `payment_source` matches with the `payment_source` specified in the order."
+        ]
+      },
+      "merchant-initiated-with-security-code2-issue": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_SECURITY_CODE"
+        ]
+      },
+      "merchant-initiated-with-security-code2-description": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if `payment_source.card.security_code` is present in the order. `security_code` can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with `security_code` is the order."
+        ]
+      },
+      "merchant-initiated-with-auth-results": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_AUTHENTICATION_RESULTS"
+        ]
+      },
+      "err-merch-init-auth-results-3ds-invalid-desc": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if 3D-Secure authentication results are present in the order. 3D-Secure authentication results can be present in the order only when customer is the payment initiator. It is semantically incorrect to perform a merchant initiated payment with 3D-Secure authentication results is the order."
+        ]
+      },
+      "merch-init-multi-purchase-units": {
+        "type": "string",
+        "enum": [
+          "MERCHANT_INITIATED_WITH_MULTIPLE_PURCHASE_UNITS"
+        ]
+      },
+      "err-merch-init-multi-units-not-supported-desc": {
+        "type": "string",
+        "enum": [
+          "`stored_payment_source.payment_initiator` = `MERCHANT` is not supported if more than one purchase_unit is present in the Order. Merchant initiated payments are not supported from orders with more than one purchase_unit. Please retry the request with multiple Order requests (one for each purchase_unit)."
+        ]
+      },
+      "return-url-required2-issue": {
+        "type": "string",
+        "enum": [
+          "RETURN_URL_REQUIRED"
+        ]
+      },
+      "return-url-required2-description": {
+        "type": "string",
+        "enum": [
+          "The return url is required when attempting to vault this source."
+        ]
+      },
+      "cancel-url-required2-issue": {
+        "type": "string",
+        "enum": [
+          "CANCEL_URL_REQUIRED"
+        ]
+      },
+      "cancel-url-required2-description": {
+        "type": "string",
+        "enum": [
+          "The cancel url is required when attempting to vault this source."
+        ]
+      },
+      "setup-error-for-bank1-issue": {
+        "type": "string",
+        "enum": [
+          "SETUP_ERROR_FOR_BANK"
+        ]
+      },
+      "setup-error-for-bank1-description": {
+        "type": "string",
+        "enum": [
+          "The API Caller account setup, for bank payments, is incomplete or incorrect. Please contact your PayPal account manager."
+        ]
+      },
+      "bank-not-supported-for-verification1-issue": {
+        "type": "string",
+        "enum": [
+          "BANK_NOT_SUPPORTED_FOR_VERIFICATION"
+        ]
+      },
+      "bank-not-supported-for-verification1-description": {
+        "type": "string",
+        "enum": [
+          "Verification for this bank account is not supported."
+        ]
+      },
+      "payer-action-required1-issue": {
+        "type": "string",
+        "enum": [
+          "PAYER_ACTION_REQUIRED"
+        ]
+      },
+      "payer-action-required1-description": {
+        "type": "string",
+        "enum": [
+          "Transaction cannot complete successfully, instruct the buyer to return to PayPal."
+        ]
+      },
+      "apple-pay-amount-mismatch3-issue": {
+        "type": "string",
+        "enum": [
+          "APPLE_PAY_AMOUNT_MISMATCH"
+        ]
+      },
+      "apple-pay-amount-mismatch3-description": {
+        "type": "string",
+        "enum": [
+          "The 'amount' specified in the Order should match the amount that was viewed and authorized by the payer/buyer on Apple Pay. If the amount has changed, please redirect the buyer to authorize the order again via Apple Pay."
+        ]
+      },
+      "currency-not-supported-for-bank1-issue": {
+        "type": "string",
+        "enum": [
+          "CURRENCY_NOT_SUPPORTED_FOR_BANK"
+        ]
+      },
+      "currency-not-supported-for-bank1-description": {
+        "type": "string",
+        "enum": [
+          "The payment_source does not support the currency of the Order. For ACH debit, only USD is supported and for SEPA debit, only EUR is supported."
+        ]
+      },
+      "only-one-bank-source-allowed1-issue": {
+        "type": "string",
+        "enum": [
+          "ONLY_ONE_BANK_SOURCE_ALLOWED"
+        ]
+      },
+      "only-one-bank-source-allowed1-description": {
+        "type": "string",
+        "enum": [
+          "More than one payment method within the bank payment object is not supported."
+        ]
+      },
+      "invalid-iban1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_IBAN"
+        ]
+      },
+      "invalid-iban1-description": {
+        "type": "string",
+        "enum": [
+          "IBAN provided is not a valid bank account number."
+        ]
+      },
+      "iban-country-not-supported1-issue": {
+        "type": "string",
+        "enum": [
+          "IBAN_COUNTRY_NOT_SUPPORTED"
+        ]
+      },
+      "iban-country-not-supported1-description": {
+        "type": "string",
+        "enum": [
+          "Country code of issuer bank for the provided IBAN is not supported for SEPA debit payments."
+        ]
+      },
+      "card-number-required2-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_NUMBER_REQUIRED"
+        ]
+      },
+      "card-number-required2-description": {
+        "type": "string",
+        "enum": [
+          "The card number is required when attempting to process payment with card."
+        ]
+      },
+      "card-expiry-required2-issue": {
+        "type": "string",
+        "enum": [
+          "CARD_EXPIRY_REQUIRED"
+        ]
+      },
+      "card-expiry-required2-description": {
+        "type": "string",
+        "enum": [
+          "The card expiry is required when attempting to process payment with card."
+        ]
+      },
+      "vault-instruction-required3-issue": {
+        "type": "string",
+        "enum": [
+          "VAULT_INSTRUCTION_REQUIRED"
+        ]
+      },
+      "vault-instruction-required3-description": {
+        "type": "string",
+        "enum": [
+          "Vault instruction is required. Please use `vault.store_in_vault` to provide vault instruction."
+        ]
+      },
+      "mismatched-vault-id-to-payment-source3-issue": {
+        "type": "string",
+        "enum": [
+          "MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE"
+        ]
+      },
+      "mismatched-vault-id-to-payment-source3-description": {
+        "type": "string",
+        "enum": [
+          "The vault_id does not match the payment_source provided. Please verify that the vault_id token used refers to the matching payment_source and try again. For example, a PayPal token cannot be passed in the vault_id field in the payment_source.card object."
+        ]
+      },
+      "not-eligible-for-pnref-processing3-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PNREF_PROCESSING"
+        ]
+      },
+      "not-eligible-for-pnref-processing3-description": {
+        "type": "string",
+        "enum": [
+          "API caller is not enabled to process payments with the `pnref`. Please contact customer support to request permissions to process transactions with PNREF."
+        ]
+      },
+      "not-eligible-paypal-tx-id-processing-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_ELIGIBLE_FOR_PAYPAL_TRANSACTION_ID_PROCESSING"
+        ]
+      },
+      "paypal-tx-id-processing-permission-needed-desc": {
+        "type": "string",
+        "enum": [
+          "API caller is not enable to process payments using `paypal_transaction_id`. Please contact customer support to request permissions to process transactions with PayPal transaction ID."
+        ]
+      },
+      "paypal-transaction-id-not-found3-issue": {
+        "type": "string",
+        "enum": [
+          "PAYPAL_TRANSACTION_ID_NOT_FOUND"
+        ]
+      },
+      "paypal-transaction-id-not-found3-description": {
+        "type": "string",
+        "enum": [
+          "Specified `paypal_transaction_id` was not found. Verify the value and try the request again."
+        ]
+      },
+      "pnref-not-found3-issue": {
+        "type": "string",
+        "enum": [
+          "PNREF_NOT_FOUND"
+        ]
+      },
+      "pnref-not-found3-description": {
+        "type": "string",
+        "enum": [
+          "Specified `pnref` was not found. Verify the value and try the request again."
+        ]
+      },
+      "invalid-security-code-length3-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_SECURITY_CODE_LENGTH"
+        ]
+      },
+      "invalid-security-code-length3-description": {
+        "type": "string",
+        "enum": [
+          "The security_code length is invalid for the specified card brand."
+        ]
+      },
+      "platform-fee-payee-cannot-be-same-as-payer-issue": {
+        "type": "string",
+        "enum": [
+          "PLATFORM_FEE_PAYEE_CANNOT_BE_SAME_AS_PAYER"
+        ]
+      },
+      "payer-cannot-pay-themselves-error": {
+        "type": "string",
+        "enum": [
+          "The payer cannot pay themselves. The recipient account of the platform fees must be different from the payer account."
+        ]
+      },
+      "required-param-for-cust-initiated-payment-issue": {
+        "type": "string",
+        "enum": [
+          "REQUIRED_PARAMETER_FOR_CUSTOMER_INITIATED_PAYMENT"
+        ]
+      },
+      "req-param-cust-present-initiator-merch-error": {
+        "type": "string",
+        "enum": [
+          "This parameter is required when the customer is present. If the customer is not present, indicate so by sending payment_initiator=`MERCHANT`. For details, see <a href=\"https://developer.paypal.com/docs/api/orders/v2/#definition-card_stored_credential\">Stored Credential</a>."
+        ]
+      },
+      "identifier-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "IDENTIFIER_NOT_FOUND"
+        ]
+      },
+      "identifier-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Specified identifier was not found. Please verify the correct identifier was used and try the request again."
+        ]
+      },
+      "shipment-tracker-shipment-direction": {
+        "type": "string",
+        "description": "To denote whether the shipment is sent forward to the receiver or returned back.",
+        "minLength": 1,
+        "maxLength": 50,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "FORWARD",
+          "RETURN"
+        ]
+      },
+      "shipment-tracker-shipment-uploader": {
+        "readOnly": true,
+        "type": "string",
+        "description": "To denote which party uploaded the shipment tracking info.",
+        "minLength": 1,
+        "maxLength": 50,
+        "pattern": "^[0-9A-Z_]+$",
+        "enum": [
+          "MERCHANT",
+          "CONSUMER",
+          "PARTNER"
+        ]
+      },
+      "missing-required-parameter5-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter5-description": {
+        "type": "string",
+        "enum": [
+          "A required field / parameter is missing."
+        ]
+      },
+      "invalid-string-length5-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length5-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long."
+        ]
+      },
+      "invalid-parameter-value5-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value5-description": {
+        "type": "string",
+        "enum": [
+          "A parameter value is not valid."
+        ]
+      },
+      "invalid-parameter-syntax5-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_SYNTAX"
+        ]
+      },
+      "invalid-parameter-syntax5-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field does not conform to the expected format."
+        ]
+      },
+      "permission-denied3-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED"
+        ]
+      },
+      "permission-denied3-description": {
+        "type": "string",
+        "enum": [
+          "You do not have permission to access or perform operations on this resource."
+        ]
+      },
+      "capture-status-not-valid-issue": {
+        "type": "string",
+        "enum": [
+          "CAPTURE_STATUS_NOT_VALID"
+        ]
+      },
+      "capture-status-not-valid-description": {
+        "type": "string",
+        "enum": [
+          "Invalid capture status. Tracker information can only be added to captures in `COMPLETED` state."
+        ]
+      },
+      "item-sku-mismatch-issue": {
+        "type": "string",
+        "enum": [
+          "ITEM_SKU_MISMATCH"
+        ]
+      },
+      "item-sku-mismatch-description": {
+        "type": "string",
+        "enum": [
+          "Item sku must match one of the items sku that was provided during order creation."
+        ]
+      },
+      "capture-id-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "CAPTURE_ID_NOT_FOUND"
+        ]
+      },
+      "capture-id-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Specified capture ID does not exist. Check the capture ID and try again."
+        ]
+      },
+      "msp-not-supported-issue": {
+        "type": "string",
+        "enum": [
+          "MSP_NOT_SUPPORTED"
+        ]
+      },
+      "msp-not-supported-description": {
+        "type": "string",
+        "enum": [
+          "Multiple purchase units are not supported for this operation."
+        ]
+      },
+      "field-not-patchable1-issue": {
+        "type": "string",
+        "enum": [
+          "FIELD_NOT_PATCHABLE"
+        ]
+      },
+      "field-not-patchable1-description": {
+        "type": "string",
+        "enum": [
+          "Field cannot be patched."
+        ]
+      },
+      "invalid-parameter-value6-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PARAMETER_VALUE"
+        ]
+      },
+      "invalid-parameter-value6-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is invalid."
+        ]
+      },
+      "missing-required-parameter6-issue": {
+        "type": "string",
+        "enum": [
+          "MISSING_REQUIRED_PARAMETER"
+        ]
+      },
+      "missing-required-parameter6-description": {
+        "type": "string",
+        "enum": [
+          "A required field or parameter is missing."
+        ]
+      },
+      "invalid-string-length6-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_STRING_LENGTH"
+        ]
+      },
+      "invalid-string-length6-description": {
+        "type": "string",
+        "enum": [
+          "The value of a field is either too short or too long."
+        ]
+      },
+      "invalid-patch-operation1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_PATCH_OPERATION"
+        ]
+      },
+      "invalid-patch-operation1-description": {
+        "type": "string",
+        "enum": [
+          "The operation cannot be honored. Cannot add a property that's already present, use replace. Cannot remove a property thats not present, use add. Cannot replace a property thats not present, use add."
+        ]
+      },
+      "malformed-request-json5-issue": {
+        "type": "string",
+        "enum": [
+          "MALFORMED_REQUEST_JSON"
+        ]
+      },
+      "malformed-request-json5-description": {
+        "type": "string",
+        "enum": [
+          "The request JSON is not well formed."
+        ]
+      },
+      "permission-denied4-issue": {
+        "type": "string",
+        "enum": [
+          "PERMISSION_DENIED"
+        ]
+      },
+      "permission-denied4-description": {
+        "type": "string",
+        "enum": [
+          "You do not have permission to access or perform operations on this resource."
+        ]
+      },
+      "tracker-id-not-found-issue": {
+        "type": "string",
+        "enum": [
+          "TRACKER_ID_NOT_FOUND"
+        ]
+      },
+      "tracker-id-not-found-description": {
+        "type": "string",
+        "enum": [
+          "Specified tracker ID does not exist. Check the tracker ID and try again."
+        ]
+      },
+      "invalid-json-pointer-format1-issue": {
+        "type": "string",
+        "enum": [
+          "INVALID_JSON_POINTER_FORMAT"
+        ]
+      },
+      "invalid-json-pointer-format1-description": {
+        "type": "string",
+        "enum": [
+          "Path should be a valid [JSON Pointer](https://tools.ietf.org/html/rfc6901) that references a location within the request where the operation is performed."
+        ]
+      },
+      "not-patchable1-issue": {
+        "type": "string",
+        "enum": [
+          "NOT_PATCHABLE"
+        ]
+      },
+      "not-patchable1-description": {
+        "type": "string",
+        "enum": [
+          "Cannot be patched."
+        ]
+      },
+      "patch-value-required1-issue": {
+        "type": "string",
+        "enum": [
+          "PATCH_VALUE_REQUIRED"
+        ]
+      },
+      "patch-value-required1-description": {
+        "type": "string",
+        "enum": [
+          "Specify a `value` for the field being patched."
+        ]
+      },
+      "patch-path-required1-issue": {
+        "type": "string",
+        "enum": [
+          "PATCH_PATH_REQUIRED"
+        ]
+      },
+      "patch-path-required1-description": {
+        "type": "string",
+        "enum": [
+          "Specify a `value` for the field in which the operation needs to be performed."
+        ]
+      },
+      "item-sku-mismatch1-issue": {
+        "type": "string",
+        "enum": [
+          "ITEM_SKU_MISMATCH"
+        ]
+      },
+      "item-sku-mismatch1-description": {
+        "type": "string",
+        "enum": [
+          "Item sku must match one of the items sku that was provided during order creation."
+        ]
       }
     },
     "examples": {


### PR DESCRIPTION
1. Removed empty "required": [] property.

2. Removed Content-Type header explicit definition and fixed all references. This info was already conveyed in endpoint request body.

3. Used allOf to tackle sibling data added for setting information for readOnly and descriptions.

4. Fixed duplicate/invalid naming of schemas through renaming and kept title itself short (less than 50 characters).

5. Re-ordered operation object parameters to ensure required parameters come first.

6. Removed unused components.

7. Converted inline schemas to global schemas using auto-fix feature of APIMatic vscode extension.